### PR TITLE
Cache AI explanations per diff

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,9 +42,9 @@
   - [ ] Add confirmation above a configurable threshold
   - [ ] Consider filtering by file or hunk
 
-- [ ] Cache AI explanations per diff/session
-  - [ ] Reuse generated hunk explanations when reopening the same diff
-  - [ ] Clear explanation cache when the diff changes
+- [x] Cache AI explanations per diff/session
+  - [x] Reuse generated hunk explanations when reopening the same diff
+  - [x] Clear explanation cache when the diff changes
 
 - [ ] Document compatibility expectations
   - [ ] Note that the package ships raw `.ts` extension files

--- a/src/explanation-controller.ts
+++ b/src/explanation-controller.ts
@@ -55,7 +55,17 @@ export class ExplanationController {
   constructor(
     private readonly tui: ReviewTui,
     private readonly explainer?: DiffExplainer,
-  ) {}
+    cachedExplanations: Map<string, string> = new Map(),
+    private readonly onExplanationsChanged?: (
+      explanations: Map<string, string>,
+    ) => void,
+  ) {
+    for (const [key, text] of cachedExplanations) {
+      const trimmed = text.trim();
+      if (trimmed)
+        this.explanations.set(key, { status: "ready", text: trimmed });
+    }
+  }
 
   get isAvailable(): boolean {
     return this.explainer != null;
@@ -98,6 +108,7 @@ export class ExplanationController {
           status: "ready",
           text: finalText.trim() || text.trim() || "No explanation returned.",
         });
+        this.emitExplanationsChanged();
       })
       .catch((error) => {
         if (requestId !== this.requestId) return;
@@ -119,6 +130,18 @@ export class ExplanationController {
   dispose(): void {
     this.abortController?.abort();
     this.stopLoadingTimer();
+  }
+
+  private emitExplanationsChanged(): void {
+    if (!this.onExplanationsChanged) return;
+
+    const readyExplanations = new Map<string, string>();
+    for (const [key, explanation] of this.explanations) {
+      if (explanation.status === "ready") {
+        readyExplanations.set(key, explanation.text);
+      }
+    }
+    this.onExplanationsChanged(readyExplanations);
   }
 
   private startLoadingTimer(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,17 @@ import { ReviewComponent } from "./review-component.ts";
 import type { DiffSource, ReviewComment, ReviewResult } from "./types.ts";
 
 const DIFF_REVIEW_CACHE_ENTRY = "pi-diff-review-cache";
+const DIFF_REVIEW_EXPLANATION_CACHE_ENTRY = "pi-diff-review-explanation-cache";
 
 type DiffReviewCacheEntry = {
   cacheKey: string;
   comments: ReviewComment[];
+  updatedAt: number;
+};
+
+type DiffExplanationCacheEntry = {
+  cacheKey: string;
+  explanations: Record<string, string>;
   updatedAt: number;
 };
 
@@ -71,6 +78,58 @@ function persistCachedComments(
   } satisfies DiffReviewCacheEntry);
 }
 
+function getCachedExplanations(
+  ctx: ExtensionCommandContext,
+  cacheKey: string,
+): Map<string, string> {
+  let latest: DiffExplanationCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (
+      entry.type !== "custom" ||
+      entry.customType !== DIFF_REVIEW_EXPLANATION_CACHE_ENTRY
+    ) {
+      continue;
+    }
+
+    const data = entry.data as Partial<DiffExplanationCacheEntry> | undefined;
+    if (
+      data?.cacheKey !== cacheKey ||
+      !data.explanations ||
+      typeof data.explanations !== "object" ||
+      Array.isArray(data.explanations)
+    ) {
+      continue;
+    }
+
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        cacheKey: data.cacheKey,
+        explanations: Object.fromEntries(
+          Object.entries(data.explanations).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string",
+          ),
+        ),
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return new Map(Object.entries(latest?.explanations ?? {}));
+}
+
+function persistCachedExplanations(
+  pi: ExtensionAPI,
+  cacheKey: string,
+  explanations: Map<string, string>,
+): void {
+  pi.appendEntry(DIFF_REVIEW_EXPLANATION_CACHE_ENTRY, {
+    cacheKey,
+    explanations: Object.fromEntries(explanations),
+    updatedAt: Date.now(),
+  } satisfies DiffExplanationCacheEntry);
+}
+
 export function registerDiffReviewCommand(pi: ExtensionAPI): void {
   pi.registerCommand("diff", {
     description: "Review a git diff in a custom TUI (/diff [git diff args])",
@@ -94,9 +153,16 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
       const reviewLines = parseDiff(diffText);
       const cacheKey = getDiffCacheKey(ctx.cwd, source, diffText);
       const comments = getCachedComments(ctx, cacheKey);
+      const explanations = getCachedExplanations(ctx, cacheKey);
       if (comments.size > 0) {
         ctx.ui.notify(
           `Restored ${comments.size} cached diff comment${comments.size === 1 ? "" : "s"}.`,
+          "info",
+        );
+      }
+      if (explanations.size > 0) {
+        ctx.ui.notify(
+          `Restored ${explanations.size} cached hunk explanation${explanations.size === 1 ? "" : "s"}.`,
           "info",
         );
       }
@@ -113,6 +179,10 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
             new PiModelDiffExplainer(ctx),
             (updatedComments) => {
               persistCachedComments(pi, cacheKey, updatedComments.values());
+            },
+            explanations,
+            (updatedExplanations) => {
+              persistCachedExplanations(pi, cacheKey, updatedExplanations);
             },
           );
         },

--- a/src/review-component.ts
+++ b/src/review-component.ts
@@ -62,6 +62,8 @@ export class ReviewComponent {
     private done: (result: ReviewResult) => void,
     private explainer?: DiffExplainer,
     private onCommentsChanged?: (comments: Map<string, ReviewComment>) => void,
+    cachedExplanations?: Map<string, string>,
+    private onExplanationsChanged?: (explanations: Map<string, string>) => void,
   ) {
     const firstCommentable = this.lines.findIndex((line) => line.commentable);
     this.navigation = new ReviewNavigationState(
@@ -69,7 +71,12 @@ export class ReviewComponent {
       firstCommentable >= 0 ? firstCommentable : 0,
     );
     this.lines.forEach((line, index) => this.lineIndexById.set(line.id, index));
-    this.explanationController = new ExplanationController(tui, explainer);
+    this.explanationController = new ExplanationController(
+      tui,
+      explainer,
+      cachedExplanations,
+      onExplanationsChanged,
+    );
 
     this.editor = new Editor(tui as never, {
       borderColor: (s) => theme.fg("accent", s),

--- a/test/explanation-controller.test.ts
+++ b/test/explanation-controller.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { getCurrentHunkScope } from "../src/explanation-controller.ts";
+import {
+  ExplanationController,
+  getCurrentHunkScope,
+} from "../src/explanation-controller.ts";
+import type { DiffExplainer, ExplanationScope } from "../src/explain.ts";
 import type { ReviewLine } from "../src/types.ts";
 
 function line(
@@ -47,5 +51,56 @@ describe("getCurrentHunkScope", () => {
       ),
       undefined,
     );
+  });
+});
+
+describe("ExplanationController", () => {
+  const scope: ExplanationScope = {
+    key: "hunk:src/app.ts:@@ -1 +1 @@:0:1",
+    kind: "hunk",
+    title: "src/app.ts @@ -1 +1 @@",
+    filePath: "src/app.ts",
+    diffText: "-old\n+new",
+  };
+
+  it("restores ready explanations from cache", () => {
+    const controller = new ExplanationController(
+      { requestRender: () => undefined },
+      undefined,
+      new Map([[scope.key, "cached explanation"]]),
+    );
+
+    assert.deepEqual(controller.getState(scope), {
+      status: "ready",
+      text: "cached explanation",
+    });
+  });
+
+  it("emits ready explanations after generation finishes", async () => {
+    let changed: Map<string, string> | undefined;
+    const explainer: DiffExplainer = {
+      async explain(_scope, options) {
+        options?.onDelta?.("partial ");
+        return "final explanation";
+      },
+    };
+    const controller = new ExplanationController(
+      { requestRender: () => undefined },
+      explainer,
+      new Map(),
+      (explanations) => {
+        changed = explanations;
+      },
+    );
+
+    controller.ensure(scope);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.deepEqual(controller.getState(scope), {
+      status: "ready",
+      text: "final explanation",
+    });
+    assert.equal(changed?.get(scope.key), "final explanation");
+    controller.dispose();
   });
 });


### PR DESCRIPTION
## Summary
- Persist generated hunk explanations in the current pi session
- Restore cached explanations when reopening the same unchanged diff
- Use the existing diff hash cache key so explanation cache misses when the diff changes
- Add tests for cached explanation restore/update behavior
- Mark the FEATURES.md explanation cache section complete

## Tests
- npm run check