### PR TITLE
Fix inline ask and explanation placement

### DIFF
--- a/src/explanation/controller.ts
+++ b/src/explanation/controller.ts
@@ -62,11 +62,18 @@ export class ExplanationController {
     private readonly onExplanationsChanged?: (
       explanations: Map<string, string>,
     ) => void,
+    cachedAskText?: string,
+    private readonly onAskChanged?: (state?: ExplanationState) => void,
   ) {
     for (const [key, text] of cachedExplanations) {
       const trimmed = text.trim();
       if (trimmed)
         this.explanations.set(key, { status: "ready", text: trimmed });
+    }
+
+    const trimmedAskText = cachedAskText?.trim();
+    if (trimmedAskText) {
+      this.askState = { status: "ready", text: trimmedAskText };
     }
   }
 
@@ -90,6 +97,7 @@ export class ExplanationController {
     const requestId = ++this.askRequestId;
     let text = "";
     this.askState = { status: "loading", text };
+    this.onAskChanged?.(this.askState);
     this.startLoadingTimer();
 
     void this.explainer
@@ -99,6 +107,7 @@ export class ExplanationController {
           if (requestId !== this.askRequestId) return;
           text += delta;
           this.askState = { status: "loading", text };
+          this.onAskChanged?.(this.askState);
           this.tui.requestRender();
         },
       })
@@ -108,6 +117,7 @@ export class ExplanationController {
           status: "ready",
           text: finalText.trim() || text.trim() || "No answer returned.",
         };
+        this.onAskChanged?.(this.askState);
       })
       .catch((error) => {
         if (requestId !== this.askRequestId) return;
@@ -116,6 +126,7 @@ export class ExplanationController {
           status: "error",
           message: error instanceof Error ? error.message : String(error),
         };
+        this.onAskChanged?.(this.askState);
       })
       .finally(() => {
         if (requestId !== this.askRequestId) return;
@@ -134,6 +145,7 @@ export class ExplanationController {
     this.askAbortController?.abort();
     this.askAbortController = undefined;
     this.askState = undefined;
+    this.onAskChanged?.(undefined);
   }
 
   ensure(scope: ExplanationScope | undefined): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,12 +10,14 @@ import { buildReviewPrompt } from "./review/prompt.ts";
 import { ReviewComponent } from "./review/component.ts";
 import type {
   DiffSource,
+  PersistedAsk,
   ReviewComment,
   ReviewResult,
 } from "./review/types.ts";
 
 const DIFF_REVIEW_CACHE_ENTRY = "pi-diff-review-cache";
 const DIFF_REVIEW_EXPLANATION_CACHE_ENTRY = "pi-diff-review-explanation-cache";
+const DIFF_REVIEW_ASK_CACHE_ENTRY = "pi-diff-review-ask-cache";
 
 type DiffReviewCacheEntry = {
   cacheKey: string;
@@ -26,6 +28,12 @@ type DiffReviewCacheEntry = {
 type DiffExplanationCacheEntry = {
   cacheKey: string;
   explanations: Record<string, string>;
+  updatedAt: number;
+};
+
+type DiffAskCacheEntry = {
+  cacheKey: string;
+  ask?: PersistedAsk;
   updatedAt: number;
 };
 
@@ -134,6 +142,53 @@ function persistCachedExplanations(
   } satisfies DiffExplanationCacheEntry);
 }
 
+function getCachedAsk(
+  ctx: ExtensionCommandContext,
+  cacheKey: string,
+): PersistedAsk | undefined {
+  let latest: DiffAskCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type !== "custom" || entry.customType !== DIFF_REVIEW_ASK_CACHE_ENTRY) {
+      continue;
+    }
+
+    const data = entry.data as Partial<DiffAskCacheEntry> | undefined;
+    if (data?.cacheKey !== cacheKey) continue;
+
+    const ask = data.ask;
+    const validAsk =
+      ask &&
+      typeof ask === "object" &&
+      typeof ask.scopeKey === "string" &&
+      typeof ask.anchorLineId === "string" &&
+      typeof ask.text === "string"
+        ? ask
+        : undefined;
+
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        cacheKey: data.cacheKey,
+        ask: validAsk,
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return latest?.ask;
+}
+
+function persistCachedAsk(
+  pi: ExtensionAPI,
+  cacheKey: string,
+  ask?: PersistedAsk,
+): void {
+  pi.appendEntry(DIFF_REVIEW_ASK_CACHE_ENTRY, {
+    cacheKey,
+    ask,
+    updatedAt: Date.now(),
+  } satisfies DiffAskCacheEntry);
+}
+
 export function registerDiffReviewCommand(pi: ExtensionAPI): void {
   pi.registerCommand("diff", {
     description: "Review a git diff in a custom TUI (/diff [git diff args])",
@@ -158,6 +213,7 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
       const cacheKey = getDiffCacheKey(ctx.cwd, source, diffText);
       const comments = getCachedComments(ctx, cacheKey);
       const explanations = getCachedExplanations(ctx, cacheKey);
+      const ask = getCachedAsk(ctx, cacheKey);
       if (comments.size > 0) {
         ctx.ui.notify(
           `Restored ${comments.size} cached diff comment${comments.size === 1 ? "" : "s"}.`,
@@ -169,6 +225,9 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
           `Restored ${explanations.size} cached hunk explanation${explanations.size === 1 ? "" : "s"}.`,
           "info",
         );
+      }
+      if (ask) {
+        ctx.ui.notify("Restored cached ask answer.", "info");
       }
 
       const result = await ctx.ui.custom<ReviewResult>(
@@ -187,6 +246,10 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
             explanations,
             (updatedExplanations) => {
               persistCachedExplanations(pi, cacheKey, updatedExplanations);
+            },
+            ask,
+            (updatedAsk) => {
+              persistCachedAsk(pi, cacheKey, updatedAsk);
             },
           );
         },

--- a/src/review/component.ts
+++ b/src/review/component.ts
@@ -32,6 +32,7 @@ import { padToWidth, lineNumberCell } from "../render/utils.ts";
 import { buildSplitDiffRows } from "../diff/split.ts";
 import type {
   DiffRenderMode,
+  PersistedAsk,
   ReviewComment,
   ReviewLine,
   ReviewResult,
@@ -86,8 +87,10 @@ export class ReviewComponent {
 
   private inlineAnnotationsVisible = true;
   private visibleExplanationKeys = new Set<string>();
+  private explanationAnchorByScope = new Map<string, number>();
   private askInputMode = false;
   private askScope?: ExplanationScope;
+  private askAnchorIndex?: number;
   private explanationController: ExplanationController;
   private editor: Editor;
   private splitRows?: SplitDiffRow[];
@@ -117,6 +120,8 @@ export class ReviewComponent {
     private onCommentsChanged?: (comments: Map<string, ReviewComment>) => void,
     cachedExplanations?: Map<string, string>,
     private onExplanationsChanged?: (explanations: Map<string, string>) => void,
+    cachedAsk?: PersistedAsk,
+    private onAskChanged?: (ask?: PersistedAsk) => void,
   ) {
     const firstCommentable = this.lines.findIndex((line) => line.commentable);
     this.navigation = new ReviewNavigationState(
@@ -125,11 +130,36 @@ export class ReviewComponent {
     );
     this.lines.forEach((line, index) => this.lineIndexById.set(line.id, index));
     this.search = new ReviewSearchState(this.lines);
+
+    const restoredAsk = cachedAsk
+      ? this.restorePersistedAsk(cachedAsk)
+      : undefined;
+    if (restoredAsk) {
+      this.askScope = restoredAsk.scope;
+      this.askAnchorIndex = restoredAsk.anchorIndex;
+    }
+
     this.explanationController = new ExplanationController(
       tui,
       explainer,
       cachedExplanations,
       onExplanationsChanged,
+      restoredAsk ? cachedAsk?.text : undefined,
+      (state) => {
+        if (!state) {
+          this.onAskChanged?.(undefined);
+          return;
+        }
+        if (state.status !== "ready") return;
+        if (!this.askScope || this.askAnchorIndex == null) return;
+        const anchorLine = this.lines[this.askAnchorIndex];
+        if (!anchorLine) return;
+        this.onAskChanged?.({
+          scopeKey: this.askScope.key,
+          anchorLineId: anchorLine.id,
+          text: state.text,
+        });
+      },
     );
 
     this.editor = new Editor(tui as never, {
@@ -152,6 +182,7 @@ export class ReviewComponent {
           this.explanationController.ask(this.askScope, question);
         } else {
           this.askScope = undefined;
+          this.askAnchorIndex = undefined;
         }
         this.invalidateAnnotatedRows();
         this.tui.requestRender(true);
@@ -260,7 +291,11 @@ export class ReviewComponent {
       return;
     }
     if (data === "q") {
-      this.done({ action: "cancel" });
+      if (this.hasSelection()) {
+        this.clearSelection();
+      } else {
+        this.done({ action: "cancel" });
+      }
       return;
     }
     if (data === "h") {
@@ -701,10 +736,10 @@ export class ReviewComponent {
     const scope = getCurrentHunkScope(this.lines, lineIndex);
     if (!scope) return;
 
-    const end = this.getHunkEndIndex(lineIndex);
-    if (end !== lineIndex) return;
-
-    if (this.visibleExplanationKeys.has(scope.key)) {
+    if (
+      this.visibleExplanationKeys.has(scope.key) &&
+      this.getExplanationAnchorIndex(lineIndex, scope.key) === lineIndex
+    ) {
       const explanation = this.explanationController.getState(scope);
       if (!this.explanationController.isAvailable) {
         this.pushExplanationBlock(rows, "Explanation unavailable.", width);
@@ -727,11 +762,19 @@ export class ReviewComponent {
       }
     }
 
-    if (this.askInputMode && this.askScope?.key === scope.key) {
+    if (
+      this.askInputMode &&
+      this.askScope?.key === scope.key &&
+      this.askAnchorIndex === lineIndex
+    ) {
       this.pushInlineEditorBlock(rows, "Ask about this hunk", width);
     }
 
-    if (!this.askInputMode && this.askScope?.key === scope.key) {
+    if (
+      !this.askInputMode &&
+      this.askScope?.key === scope.key &&
+      this.askAnchorIndex === lineIndex
+    ) {
       const askState = this.explanationController.getAskState();
       if (askState) this.pushAskBlock(rows, askState, width);
     }
@@ -909,6 +952,27 @@ export class ReviewComponent {
     return comments.sort((a, b) => a.id.localeCompare(b.id));
   }
 
+  private restorePersistedAsk(
+    cachedAsk: PersistedAsk,
+  ): { scope: ExplanationScope; anchorIndex: number } | undefined {
+    const anchorIndex = this.lineIndexById.get(cachedAsk.anchorLineId);
+    if (anchorIndex != null) {
+      const scope = getCurrentHunkScope(this.lines, anchorIndex);
+      if (scope?.key === cachedAsk.scopeKey) {
+        return { scope, anchorIndex };
+      }
+    }
+
+    for (let index = 0; index < this.lines.length; index++) {
+      const scope = getCurrentHunkScope(this.lines, index);
+      if (scope?.key === cachedAsk.scopeKey) {
+        return { scope, anchorIndex: index };
+      }
+    }
+
+    return undefined;
+  }
+
   private getHunkEndIndex(selected: number): number | undefined {
     const selectedLine = this.lines[selected];
     if (!selectedLine?.filePath || !selectedLine.hunkLabel) return undefined;
@@ -922,6 +986,15 @@ export class ReviewComponent {
       end++;
     }
     return end;
+  }
+
+  private getExplanationAnchorIndex(
+    lineIndex: number,
+    scopeKey: string,
+  ): number | undefined {
+    return (
+      this.explanationAnchorByScope.get(scopeKey) ?? this.getHunkEndIndex(lineIndex)
+    );
   }
 
   private renderSplitDiffRowAt(splitRowIndex: number, width: number): string {
@@ -975,6 +1048,7 @@ export class ReviewComponent {
     if (!scope) return;
     this.clearAsk();
     this.askScope = scope;
+    this.askAnchorIndex = this.selected;
     this.askInputMode = true;
     this.inlineAnnotationsVisible = true;
     this.editor.setText("");
@@ -985,7 +1059,10 @@ export class ReviewComponent {
   private exitAskInputMode(): void {
     this.askInputMode = false;
     this.editor.setText("");
-    if (!this.explanationController.getAskState()) this.askScope = undefined;
+    if (!this.explanationController.getAskState()) {
+      this.askScope = undefined;
+      this.askAnchorIndex = undefined;
+    }
     this.invalidateAnnotatedRows();
     this.tui.requestRender(true);
   }
@@ -993,6 +1070,7 @@ export class ReviewComponent {
   private clearAsk(): void {
     this.askInputMode = false;
     this.askScope = undefined;
+    this.askAnchorIndex = undefined;
     this.explanationController.clearAsk();
     this.editor.setText("");
     this.invalidateAnnotatedRows();
@@ -1028,6 +1106,7 @@ export class ReviewComponent {
 
   private hideInlineExplanation(): void {
     this.visibleExplanationKeys.clear();
+    this.explanationAnchorByScope.clear();
   }
 
   private toggleExplanationPane(): void {
@@ -1036,8 +1115,10 @@ export class ReviewComponent {
 
     if (this.visibleExplanationKeys.has(scope.key)) {
       this.visibleExplanationKeys.delete(scope.key);
+      this.explanationAnchorByScope.delete(scope.key);
     } else {
       this.visibleExplanationKeys.add(scope.key);
+      this.explanationAnchorByScope.set(scope.key, this.selected);
       this.ensureCurrentExplanation();
     }
 

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -42,6 +42,12 @@ export type DiffSource = {
   args: string[];
 };
 
+export type PersistedAsk = {
+  scopeKey: string;
+  anchorLineId: string;
+  text: string;
+};
+
 export type DiffRenderMode = "unified" | "split";
 
 export type SplitDiffCell = {

--- a/test/diff/source.test.ts
+++ b/test/diff/source.test.ts
@@ -51,6 +51,7 @@ describe("getDiff", () => {
         cwd,
       });
       execFileSync("git", ["config", "user.name", "Test User"], { cwd });
+      execFileSync("git", ["config", "commit.gpgsign", "false"], { cwd });
       writeFileSync(join(cwd, "example.txt"), "before\n");
       execFileSync("git", ["add", "example.txt"], { cwd });
       execFileSync("git", ["commit", "-m", "initial"], {

--- a/test/review/component.test.ts
+++ b/test/review/component.test.ts
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import { ReviewComponent } from "../../src/review/component.ts";
-import type { ReviewLine, ReviewTheme, ReviewTui } from "../../src/review/types.ts";
+import type { DiffExplainer } from "../../src/explanation/explainer.ts";
+import type {
+  PersistedAsk,
+  ReviewLine,
+  ReviewTheme,
+  ReviewTui,
+} from "../../src/review/types.ts";
 
 function buildLines(count: number): ReviewLine[] {
   return Array.from({ length: count }, (_, index) => ({
@@ -16,7 +22,15 @@ function buildLines(count: number): ReviewLine[] {
   }));
 }
 
-function createComponent(lines: ReviewLine[]): ReviewComponent {
+function createComponent(
+  lines: ReviewLine[],
+  options: {
+    explainer?: DiffExplainer;
+    cachedAsk?: PersistedAsk;
+    onAskChanged?: (ask?: PersistedAsk) => void;
+    done?: (result: { action: "submit"; comments: any[] } | { action: "cancel" }) => void;
+  } = {},
+): ReviewComponent {
   const tui: ReviewTui = {
     requestRender: () => undefined,
     terminal: { rows: 24, columns: 100 },
@@ -32,7 +46,13 @@ function createComponent(lines: ReviewLine[]): ReviewComponent {
     "test diff",
     lines,
     new Map(),
-    () => undefined,
+    options.done ?? (() => undefined),
+    options.explainer,
+    undefined,
+    undefined,
+    undefined,
+    options.cachedAsk,
+    options.onAskChanged,
   );
 }
 
@@ -46,5 +66,135 @@ describe("ReviewComponent", () => {
 
     component.handleInput("\x1b[6~");
     assert.equal((component as any).selected, 10);
+  });
+
+  it("renders the ask editor inline at the selected line", () => {
+    const component = createComponent(buildLines(6));
+
+    (component as any).selected = 1;
+    component.handleInput("a");
+    const output = component.render(100);
+
+    const selectedLineRow = output.findIndex((line) => line.includes(" line 1"));
+    const nextLineRow = output.findIndex((line) => line.includes(" line 2"));
+    const askRow = output.findIndex((line) => line.includes("Ask about this hunk"));
+
+    assert.ok(selectedLineRow >= 0);
+    assert.ok(askRow > selectedLineRow);
+    assert.ok(askRow < nextLineRow);
+  });
+
+  it("renders the explanation pane inline at the selected line", () => {
+    const component = createComponent(buildLines(6));
+
+    (component as any).selected = 1;
+    component.handleInput("?");
+    const output = component.render(100);
+
+    const selectedLineRow = output.findIndex((line) => line.includes(" line 1"));
+    const nextLineRow = output.findIndex((line) => line.includes(" line 2"));
+    const explanationRow = output.findIndex((line) =>
+      line.includes("✨ Explanation"),
+    );
+
+    assert.ok(selectedLineRow >= 0);
+    assert.ok(explanationRow > selectedLineRow);
+    assert.ok(explanationRow < nextLineRow);
+  });
+
+  it("keeps ask answers pinned to the original line", async () => {
+    const component = createComponent(buildLines(6), {
+      explainer: { explain: async () => "answer" },
+    });
+
+    (component as any).selected = 1;
+    component.handleInput("a");
+    (component as any).editor.onSubmit?.("why?");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    (component as any).selected = 2;
+    const output = component.render(100);
+
+    const originalLineRow = output.findIndex((line) => line.includes(" line 1"));
+    const movedToLineRow = output.findIndex((line) => line.includes(" line 2"));
+    const answerRow = output.findIndex((line) => line.includes("💬 Answer"));
+
+    assert.ok(answerRow > originalLineRow);
+    assert.ok(answerRow < movedToLineRow);
+  });
+
+  it("keeps explanations pinned to the original line", () => {
+    const component = createComponent(buildLines(6));
+
+    (component as any).selected = 1;
+    component.handleInput("?");
+    (component as any).selected = 2;
+    const output = component.render(100);
+
+    const originalLineRow = output.findIndex((line) => line.includes(" line 1"));
+    const movedToLineRow = output.findIndex((line) => line.includes(" line 2"));
+    const explanationRow = output.findIndex((line) =>
+      line.includes("✨ Explanation"),
+    );
+
+    assert.ok(explanationRow > originalLineRow);
+    assert.ok(explanationRow < movedToLineRow);
+  });
+
+  it("restores a cached ask answer inline", () => {
+    const component = createComponent(buildLines(6), {
+      cachedAsk: {
+        scopeKey: "hunk:src/example.ts:@@ -1,40 +1,40 @@:0:5",
+        anchorLineId: "line-1",
+        text: "cached answer",
+      },
+    });
+
+    const output = component.render(100);
+    const lineRow = output.findIndex((line) => line.includes(" line 1"));
+    const answerRow = output.findIndex((line) => line.includes("💬 Answer"));
+
+    assert.ok(answerRow > lineRow);
+  });
+
+  it("persists ask answers when they complete", async () => {
+    let persistedAsk: PersistedAsk | undefined;
+    const component = createComponent(buildLines(6), {
+      explainer: { explain: async () => "answer" },
+      onAskChanged: (ask) => {
+        persistedAsk = ask;
+      },
+    });
+
+    (component as any).selected = 1;
+    component.handleInput("a");
+    (component as any).editor.onSubmit?.("why?");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    assert.deepEqual(persistedAsk, {
+      scopeKey: "hunk:src/example.ts:@@ -1,40 +1,40 @@:0:5",
+      anchorLineId: "line-1",
+      text: "answer",
+    });
+  });
+
+  it("q clears an active selection before exiting", () => {
+    let result: { action: "submit"; comments: any[] } | { action: "cancel" } | undefined;
+    const component = createComponent(buildLines(6), {
+      done: (next) => {
+        result = next;
+      },
+    });
+
+    (component as any).selected = 1;
+    component.handleInput("J");
+    assert.equal((component as any).hasSelection(), true);
+
+    component.handleInput("q");
+    assert.equal((component as any).hasSelection(), false);
+    assert.equal(result, undefined);
+
+    component.handleInput("q");
+    assert.deepEqual(result, { action: "cancel" });
   });
 });


### PR DESCRIPTION
Hi @markokocic — sorry about the regression here.

## Summary
- render `a` ask input inline at the selected line instead of at the bottom
- render `?` explanation output inline in the diff view
- pin ask answers and explanations to their original line instead of following cursor movement through the hunk
- persist ask answers for the current diff, similar to cached comments/explanations
- make `q` clear an active selection before exiting the review
- stabilize the git diff test setup by disabling GPG signing in the temporary test repo

## Validation
- `npm test`
- `npm run typecheck`

Closes #27