### PR TITLE
Add /view review mode with persistent workspace comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ Review a branch or commit range by passing any `git diff` arguments after `/diff
 
 `/diff <git-diff-args>` is passed through to `git diff`, so these examples are equivalent to running `git diff`, `git diff --cached`, and `git diff main...HEAD` locally before opening the review UI.
 
+Open one or more files or folders with `/view`:
+
+```text
+/view src/index.ts src/review
+```
+
+`/view` expands folders into text files, renders them in the same review UI, and lets you annotate actual code lines instead of diff hunks.
+
 ### Staged vs. unstaged changes
 
 - `/diff` shows unstaged working-tree changes only.
@@ -59,6 +67,7 @@ Review a branch or commit range by passing any `git diff` arguments after `/diff
 ## Features
 
 - `/diff` reviews the current unstaged `git diff`
+- `/view <files-or-folders>` reviews source files directly
 - `/diff --cached` reviews staged changes
 - `/diff main...HEAD` reviews changes on the current branch relative to `main`
 - `/diff <git-diff-args>` passes arguments through to `git diff`
@@ -77,7 +86,9 @@ Review a branch or commit range by passing any `git diff` arguments after `/diff
 - `C` to add or edit an overall diff comment
 - `x` to delete a comment for the current line or selected range
 - `Enter` to submit comments back to pi
-- Comments are cached per session and restored when reopening the same diff
+- Comments are cached per session and restored when reopening the same diff or view
+- File comments are also persisted in a repo-local workspace store and shown again in `/view` or on matching lines in `/diff`
+- The UI indicates persisted comments that are hidden in the current files, elsewhere in the workspace, stale, or orphaned
 - `q` to exit
 
 ## Contributing

--- a/extensions/review.ts
+++ b/extensions/review.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { registerDiffReviewCommand } from "../src/index.ts";
+import { registerDiffReviewCommand, registerViewCommand } from "../src/index.ts";
 
 export default function (pi: ExtensionAPI) {
   registerDiffReviewCommand(pi);
+  registerViewCommand(pi);
 }

--- a/src/diff/source.ts
+++ b/src/diff/source.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import type { DiffSource } from "../review/types.ts";
+import { tokenizeShellArgs } from "../shared/args.ts";
 
 export function parseDiffSource(args: string): DiffSource {
   const trimmed = args.trim();
@@ -20,48 +21,12 @@ export function parseDiffSource(args: string): DiffSource {
 }
 
 function tokenizeDiffArgs(input: string): string[] {
-  const args: string[] = [];
-  let current = "";
-  let quote: '"' | "'" | undefined;
-  let escaping = false;
-
-  for (const char of input) {
-    if (escaping) {
-      current += char;
-      escaping = false;
-      continue;
-    }
-
-    if (char === "\\" && quote !== "'") {
-      escaping = true;
-      continue;
-    }
-
-    if ((char === '"' || char === "'") && !quote) {
-      quote = char;
-      continue;
-    }
-
-    if (char === quote) {
-      quote = undefined;
-      continue;
-    }
-
-    if (/\s/.test(char) && !quote) {
-      if (current) {
-        args.push(current);
-        current = "";
-      }
-      continue;
-    }
-
-    current += char;
+  try {
+    return tokenizeShellArgs(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(message.replace(/in arguments$/, "in git diff args"));
   }
-
-  if (escaping) current += "\\";
-  if (quote) throw new Error(`Unterminated ${quote} quote in git diff args`);
-  if (current) args.push(current);
-  return args;
 }
 
 export const DIFF_MAX_BUFFER_BYTES = 128 * 1024 * 1024;

--- a/src/explanation/controller.ts
+++ b/src/explanation/controller.ts
@@ -12,7 +12,40 @@ export function getCurrentHunkScope(
   selected: number,
 ): ExplanationScope | undefined {
   const selectedLine = lines[selected];
-  if (!selectedLine?.filePath || !selectedLine.hunkLabel) return undefined;
+  if (!selectedLine?.filePath) return undefined;
+  if (!selectedLine.commentable && !selectedLine.hunkLabel) return undefined;
+
+  if (!selectedLine.hunkLabel) {
+    let start = selected;
+    while (
+      start > 0 &&
+      lines[start - 1]?.filePath === selectedLine.filePath &&
+      lines[start - 1]?.commentable
+    ) {
+      start--;
+    }
+
+    let end = selected;
+    while (
+      end + 1 < lines.length &&
+      lines[end + 1]?.filePath === selectedLine.filePath &&
+      lines[end + 1]?.commentable
+    ) {
+      end++;
+    }
+
+    const diffText = lines
+      .slice(start, end + 1)
+      .map((line) => line.text.replace(/^ /, ""))
+      .join("\n");
+    return {
+      key: `file:${selectedLine.filePath}:${start}:${end}`,
+      kind: "file",
+      title: selectedLine.filePath,
+      filePath: selectedLine.filePath,
+      diffText,
+    };
+  }
 
   let start = selected;
   while (

--- a/src/explanation/explainer.ts
+++ b/src/explanation/explainer.ts
@@ -4,7 +4,7 @@ import type { AssistantMessage, Context } from "@earendil-works/pi-ai";
 
 export type ExplanationScope = {
   key: string;
-  kind: "hunk";
+  kind: "hunk" | "file";
   title: string;
   filePath?: string;
   diffText: string;
@@ -30,10 +30,30 @@ export function buildAskPrompt(
   scope: ExplanationScope,
   question: string,
 ): string {
+  if (scope.kind === "file") {
+    return `Given this code excerpt:\n\`\`\`${scope.filePath ? ` ${scope.filePath}` : ""}\n${scope.diffText}\n\`\`\`\n\n${question}`;
+  }
+
   return `Given this git diff hunk:\n\`\`\`diff\n${scope.diffText}\n\`\`\`\n\n${question}`;
 }
 
 export function buildExplanationPrompt(scope: ExplanationScope): string {
+  if (scope.kind === "file") {
+    return `Explain this code excerpt for a reviewer.
+
+Focus on:
+- what this code is doing
+- why it matters in context
+- behavioral, API, or test implications
+- notable risks or edge cases
+
+Keep it concise and practical.
+
+\`\`\`${scope.filePath ? ` ${scope.filePath}` : ""}
+${scope.diffText}
+\`\`\``;
+  }
+
   return `Explain this git diff hunk for a code reviewer.
 
 Focus on:
@@ -72,7 +92,7 @@ export class PiModelDiffExplainer implements DiffExplainer {
 
     const context: Context = {
       systemPrompt:
-        "You explain code diffs clearly and concisely for code review. Focus on intent, behavior, and risk. Avoid restating every changed line.",
+        "You explain code clearly and concisely for review. Focus on intent, behavior, and risk. Avoid restating every line.",
       messages: [
         {
           role: "user",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,197 +6,31 @@ import type {
 import { getDiff, parseDiffSource } from "./diff/source.ts";
 import { parseDiff } from "./diff/parser.ts";
 import { PiModelDiffExplainer } from "./explanation/explainer.ts";
-import { buildReviewPrompt } from "./review/prompt.ts";
+import {
+  getCachedAsk,
+  getCachedComments,
+  getCachedExplanations,
+  persistCachedAsk,
+  persistCachedComments,
+  persistCachedExplanations,
+} from "./review/cache.ts";
 import { ReviewComponent } from "./review/component.ts";
-import type {
-  DiffSource,
-  PersistedAsk,
-  ReviewComment,
-  ReviewResult,
-} from "./review/types.ts";
+import { buildReviewPrompt, buildViewReviewPrompt } from "./review/prompt.ts";
+import type { ReviewComment, ReviewLine, ReviewResult } from "./review/types.ts";
+import { WorkspaceCommentStore } from "./review/workspace-comments.ts";
+import { parseViewFiles } from "./view/parser.ts";
+import { parseViewSource, resolveViewFiles } from "./view/source.ts";
 
-const DIFF_REVIEW_CACHE_ENTRY = "pi-diff-review-cache";
-const DIFF_REVIEW_EXPLANATION_CACHE_ENTRY = "pi-diff-review-explanation-cache";
-const DIFF_REVIEW_ASK_CACHE_ENTRY = "pi-diff-review-ask-cache";
-
-type DiffReviewCacheEntry = {
-  cacheKey: string;
-  comments: ReviewComment[];
-  updatedAt: number;
-};
-
-type DiffExplanationCacheEntry = {
-  cacheKey: string;
-  explanations: Record<string, string>;
-  updatedAt: number;
-};
-
-type DiffAskCacheEntry = {
-  cacheKey: string;
-  ask?: PersistedAsk;
-  updatedAt: number;
-};
-
-function getDiffCacheKey(
-  cwd: string,
-  source: DiffSource,
-  diffText: string,
-): string {
-  const hash = createHash("sha256").update(diffText).digest("hex");
-  return `${cwd}\0${source.label}\0${hash}`;
-}
-
-function getCachedComments(
-  ctx: ExtensionCommandContext,
-  cacheKey: string,
-): Map<string, ReviewComment> {
-  let latest: DiffReviewCacheEntry | undefined;
-  for (const entry of ctx.sessionManager.getEntries()) {
-    if (
-      entry.type !== "custom" ||
-      entry.customType !== DIFF_REVIEW_CACHE_ENTRY
-    ) {
-      continue;
-    }
-
-    const data = entry.data as Partial<DiffReviewCacheEntry> | undefined;
-    if (data?.cacheKey !== cacheKey || !Array.isArray(data.comments)) {
-      continue;
-    }
-
-    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
-      latest = {
-        cacheKey: data.cacheKey,
-        comments: data.comments,
-        updatedAt: data.updatedAt ?? 0,
-      };
-    }
-  }
-
-  return new Map(
-    (latest?.comments ?? []).map((comment) => [comment.id, comment]),
-  );
-}
-
-function persistCachedComments(
-  pi: ExtensionAPI,
-  cacheKey: string,
-  comments: Iterable<ReviewComment>,
-): void {
-  pi.appendEntry(DIFF_REVIEW_CACHE_ENTRY, {
-    cacheKey,
-    comments: [...comments],
-    updatedAt: Date.now(),
-  } satisfies DiffReviewCacheEntry);
-}
-
-function getCachedExplanations(
-  ctx: ExtensionCommandContext,
-  cacheKey: string,
-): Map<string, string> {
-  let latest: DiffExplanationCacheEntry | undefined;
-  for (const entry of ctx.sessionManager.getEntries()) {
-    if (
-      entry.type !== "custom" ||
-      entry.customType !== DIFF_REVIEW_EXPLANATION_CACHE_ENTRY
-    ) {
-      continue;
-    }
-
-    const data = entry.data as Partial<DiffExplanationCacheEntry> | undefined;
-    if (
-      data?.cacheKey !== cacheKey ||
-      !data.explanations ||
-      typeof data.explanations !== "object" ||
-      Array.isArray(data.explanations)
-    ) {
-      continue;
-    }
-
-    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
-      latest = {
-        cacheKey: data.cacheKey,
-        explanations: Object.fromEntries(
-          Object.entries(data.explanations).filter(
-            (entry): entry is [string, string] =>
-              typeof entry[0] === "string" && typeof entry[1] === "string",
-          ),
-        ),
-        updatedAt: data.updatedAt ?? 0,
-      };
-    }
-  }
-
-  return new Map(Object.entries(latest?.explanations ?? {}));
-}
-
-function persistCachedExplanations(
-  pi: ExtensionAPI,
-  cacheKey: string,
-  explanations: Map<string, string>,
-): void {
-  pi.appendEntry(DIFF_REVIEW_EXPLANATION_CACHE_ENTRY, {
-    cacheKey,
-    explanations: Object.fromEntries(explanations),
-    updatedAt: Date.now(),
-  } satisfies DiffExplanationCacheEntry);
-}
-
-function getCachedAsk(
-  ctx: ExtensionCommandContext,
-  cacheKey: string,
-): PersistedAsk | undefined {
-  let latest: DiffAskCacheEntry | undefined;
-  for (const entry of ctx.sessionManager.getEntries()) {
-    if (
-      entry.type !== "custom" ||
-      entry.customType !== DIFF_REVIEW_ASK_CACHE_ENTRY
-    ) {
-      continue;
-    }
-
-    const data = entry.data as Partial<DiffAskCacheEntry> | undefined;
-    if (data?.cacheKey !== cacheKey) continue;
-
-    const ask = data.ask;
-    const validAsk =
-      ask &&
-      typeof ask === "object" &&
-      typeof ask.scopeKey === "string" &&
-      typeof ask.anchorLineId === "string" &&
-      typeof ask.text === "string"
-        ? ask
-        : undefined;
-
-    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
-      latest = {
-        cacheKey: data.cacheKey,
-        ask: validAsk,
-        updatedAt: data.updatedAt ?? 0,
-      };
-    }
-  }
-
-  return latest?.ask;
-}
-
-function persistCachedAsk(
-  pi: ExtensionAPI,
-  cacheKey: string,
-  ask?: PersistedAsk,
-): void {
-  pi.appendEntry(DIFF_REVIEW_ASK_CACHE_ENTRY, {
-    cacheKey,
-    ask,
-    updatedAt: Date.now(),
-  } satisfies DiffAskCacheEntry);
+function getReviewCacheKey(cwd: string, label: string, text: string): string {
+  const hash = createHash("sha256").update(text).digest("hex");
+  return `${cwd}\0${label}\0${hash}`;
 }
 
 export function registerDiffReviewCommand(pi: ExtensionAPI): void {
   pi.registerCommand("diff", {
     description: "Review a git diff in a custom TUI (/diff [git diff args])",
     handler: async (args: string, ctx: ExtensionCommandContext) => {
-      let source: DiffSource;
+      let source;
       let diffText: string;
       try {
         source = parseDiffSource(args);
@@ -213,62 +47,156 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
       }
 
       const reviewLines = parseDiff(diffText);
-      const cacheKey = getDiffCacheKey(ctx.cwd, source, diffText);
-      const comments = getCachedComments(ctx, cacheKey);
-      const explanations = getCachedExplanations(ctx, cacheKey);
-      const ask = getCachedAsk(ctx, cacheKey);
-      if (comments.size > 0) {
-        ctx.ui.notify(
-          `Restored ${comments.size} cached diff comment${comments.size === 1 ? "" : "s"}.`,
-          "info",
-        );
-      }
-      if (explanations.size > 0) {
-        ctx.ui.notify(
-          `Restored ${explanations.size} cached hunk explanation${explanations.size === 1 ? "" : "s"}.`,
-          "info",
-        );
-      }
-      if (ask) {
-        ctx.ui.notify("Restored cached ask answer.", "info");
-      }
+      await openReview(pi, ctx, {
+        title: source.label,
+        promptLabel: source.promptLabel,
+        cacheKey: getReviewCacheKey(ctx.cwd, source.label, diffText),
+        reviewLines,
+        buildPrompt: (comments) => buildReviewPrompt(comments, source.promptLabel),
+      });
+    },
+  });
+}
 
-      const result = await ctx.ui.custom<ReviewResult>(
-        (tui, theme, _keybindings, done) => {
-          return new ReviewComponent(
-            tui,
-            theme,
-            source.label,
-            reviewLines,
-            comments,
-            done,
-            new PiModelDiffExplainer(ctx),
-            (updatedComments) => {
-              persistCachedComments(pi, cacheKey, updatedComments.values());
-            },
-            explanations,
-            (updatedExplanations) => {
-              persistCachedExplanations(pi, cacheKey, updatedExplanations);
-            },
-            ask,
-            (updatedAsk) => {
-              persistCachedAsk(pi, cacheKey, updatedAsk);
-            },
-          );
-        },
-      );
-
-      if (!result || result.action !== "submit") return;
-      if (result.comments.length === 0) {
-        ctx.ui.notify("No review comments to send.", "info");
-        persistCachedComments(pi, cacheKey, []);
+export function registerViewCommand(pi: ExtensionAPI): void {
+  pi.registerCommand("view", {
+    description: "Review one or more files or folders in a custom TUI (/view <paths...>)",
+    handler: async (args: string, ctx: ExtensionCommandContext) => {
+      let source;
+      let files: string[];
+      try {
+        source = parseViewSource(args);
+        files = resolveViewFiles(ctx.cwd, source);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        ctx.ui.notify(`Unable to open view: ${message}`, "error");
         return;
       }
 
-      persistCachedComments(pi, cacheKey, []);
-      pi.sendUserMessage(
-        buildReviewPrompt(result.comments, source.promptLabel),
-      );
+      if (files.length === 0) {
+        ctx.ui.notify("No viewable text files matched the requested paths.", "info");
+        return;
+      }
+
+      const workspaceStore = new WorkspaceCommentStore(ctx.cwd);
+      const reviewLines = parseViewFiles(workspaceStore.rootPath, files);
+      const contentKey = reviewLines.map((line) => line.text).join("\n");
+
+      await openReview(pi, ctx, {
+        title: source.label,
+        promptLabel: source.promptLabel,
+        cacheKey: getReviewCacheKey(ctx.cwd, source.label, contentKey),
+        reviewLines,
+        workspaceStore,
+        buildPrompt: (comments) => buildViewReviewPrompt(comments, source.promptLabel),
+      });
     },
   });
+}
+
+async function openReview(
+  pi: ExtensionAPI,
+  ctx: ExtensionCommandContext,
+  options: {
+    title: string;
+    promptLabel: string;
+    cacheKey: string;
+    reviewLines: ReviewLine[];
+    buildPrompt: (comments: ReviewComment[]) => string;
+    workspaceStore?: WorkspaceCommentStore;
+  },
+): Promise<void> {
+  const workspaceStore = options.workspaceStore ?? new WorkspaceCommentStore(ctx.cwd);
+  const cachedComments = getCachedComments(ctx, options.cacheKey);
+  const comments = workspaceStore.getVisibleComments(options.reviewLines);
+  for (const [id, comment] of cachedComments) {
+    comments.set(id, comment);
+  }
+
+  const explanations = getCachedExplanations(ctx, options.cacheKey);
+  const ask = getCachedAsk(ctx, options.cacheKey);
+  const summary = () => workspaceStore.summarize(options.reviewLines);
+
+  if (cachedComments.size > 0) {
+    ctx.ui.notify(
+      `Restored ${cachedComments.size} cached review comment${cachedComments.size === 1 ? "" : "s"}.`,
+      "info",
+    );
+  }
+  if (explanations.size > 0) {
+    ctx.ui.notify(
+      `Restored ${explanations.size} cached explanation${explanations.size === 1 ? "" : "s"}.`,
+      "info",
+    );
+  }
+  if (ask) {
+    ctx.ui.notify("Restored cached ask answer.", "info");
+  }
+
+  const initialSummary = summary();
+  if (initialSummary.hiddenInCurrentFiles > 0 || initialSummary.elsewhere > 0) {
+    ctx.ui.notify(
+      [
+        initialSummary.hiddenInCurrentFiles > 0
+          ? `${initialSummary.hiddenInCurrentFiles} comments hidden in current files`
+          : undefined,
+        initialSummary.elsewhere > 0
+          ? `${initialSummary.elsewhere} comments elsewhere in the workspace`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join(" • "),
+      "info",
+    );
+  }
+  if (initialSummary.stale > 0 || initialSummary.orphaned > 0) {
+    ctx.ui.notify(
+      [
+        initialSummary.stale > 0
+          ? `${initialSummary.stale} stale comment${initialSummary.stale === 1 ? "" : "s"}`
+          : undefined,
+        initialSummary.orphaned > 0
+          ? `${initialSummary.orphaned} orphaned comment${initialSummary.orphaned === 1 ? "" : "s"}`
+          : undefined,
+      ]
+        .filter(Boolean)
+        .join(" • "),
+      "warning",
+    );
+  }
+
+  const result = await ctx.ui.custom<ReviewResult>((tui, theme, _keybindings, done) => {
+    return new ReviewComponent(
+      tui,
+      theme,
+      options.title,
+      options.reviewLines,
+      comments,
+      done,
+      new PiModelDiffExplainer(ctx),
+      (updatedComments) => {
+        persistCachedComments(pi, options.cacheKey, updatedComments.values());
+        workspaceStore.syncFromComments(options.reviewLines, updatedComments.values());
+      },
+      explanations,
+      (updatedExplanations) => {
+        persistCachedExplanations(pi, options.cacheKey, updatedExplanations);
+      },
+      ask,
+      (updatedAsk) => {
+        persistCachedAsk(pi, options.cacheKey, updatedAsk);
+      },
+      () => summary(),
+    );
+  });
+
+  if (!result || result.action !== "submit") return;
+  if (result.comments.length === 0) {
+    ctx.ui.notify("No review comments to send.", "info");
+    persistCachedComments(pi, options.cacheKey, []);
+    return;
+  }
+
+  persistCachedComments(pi, options.cacheKey, []);
+  pi.sendUserMessage(options.buildPrompt(result.comments));
 }

--- a/src/review/cache.ts
+++ b/src/review/cache.ts
@@ -1,0 +1,163 @@
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+} from "@earendil-works/pi-coding-agent";
+import type { PersistedAsk, ReviewComment } from "./types.ts";
+
+const REVIEW_COMMENT_CACHE_ENTRY = "pi-diff-review-cache";
+const REVIEW_EXPLANATION_CACHE_ENTRY = "pi-diff-review-explanation-cache";
+const REVIEW_ASK_CACHE_ENTRY = "pi-diff-review-ask-cache";
+
+type ReviewCommentCacheEntry = {
+  cacheKey: string;
+  comments: ReviewComment[];
+  updatedAt: number;
+};
+
+type ReviewExplanationCacheEntry = {
+  cacheKey: string;
+  explanations: Record<string, string>;
+  updatedAt: number;
+};
+
+type ReviewAskCacheEntry = {
+  cacheKey: string;
+  ask?: PersistedAsk;
+  updatedAt: number;
+};
+
+export function getCachedComments(
+  ctx: ExtensionCommandContext,
+  cacheKey: string,
+): Map<string, ReviewComment> {
+  let latest: ReviewCommentCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type !== "custom" || entry.customType !== REVIEW_COMMENT_CACHE_ENTRY) {
+      continue;
+    }
+
+    const data = entry.data as Partial<ReviewCommentCacheEntry> | undefined;
+    if (data?.cacheKey !== cacheKey || !Array.isArray(data.comments)) continue;
+
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        cacheKey: data.cacheKey,
+        comments: data.comments,
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return new Map((latest?.comments ?? []).map((comment) => [comment.id, comment]));
+}
+
+export function persistCachedComments(
+  pi: ExtensionAPI,
+  cacheKey: string,
+  comments: Iterable<ReviewComment>,
+): void {
+  pi.appendEntry(REVIEW_COMMENT_CACHE_ENTRY, {
+    cacheKey,
+    comments: [...comments],
+    updatedAt: Date.now(),
+  } satisfies ReviewCommentCacheEntry);
+}
+
+export function getCachedExplanations(
+  ctx: ExtensionCommandContext,
+  cacheKey: string,
+): Map<string, string> {
+  let latest: ReviewExplanationCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (
+      entry.type !== "custom" ||
+      entry.customType !== REVIEW_EXPLANATION_CACHE_ENTRY
+    ) {
+      continue;
+    }
+
+    const data = entry.data as Partial<ReviewExplanationCacheEntry> | undefined;
+    if (
+      data?.cacheKey !== cacheKey ||
+      !data.explanations ||
+      typeof data.explanations !== "object" ||
+      Array.isArray(data.explanations)
+    ) {
+      continue;
+    }
+
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        cacheKey: data.cacheKey,
+        explanations: Object.fromEntries(
+          Object.entries(data.explanations).filter(
+            (entry): entry is [string, string] =>
+              typeof entry[0] === "string" && typeof entry[1] === "string",
+          ),
+        ),
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return new Map(Object.entries(latest?.explanations ?? {}));
+}
+
+export function persistCachedExplanations(
+  pi: ExtensionAPI,
+  cacheKey: string,
+  explanations: Map<string, string>,
+): void {
+  pi.appendEntry(REVIEW_EXPLANATION_CACHE_ENTRY, {
+    cacheKey,
+    explanations: Object.fromEntries(explanations),
+    updatedAt: Date.now(),
+  } satisfies ReviewExplanationCacheEntry);
+}
+
+export function getCachedAsk(
+  ctx: ExtensionCommandContext,
+  cacheKey: string,
+): PersistedAsk | undefined {
+  let latest: ReviewAskCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (entry.type !== "custom" || entry.customType !== REVIEW_ASK_CACHE_ENTRY) {
+      continue;
+    }
+
+    const data = entry.data as Partial<ReviewAskCacheEntry> | undefined;
+    if (data?.cacheKey !== cacheKey) continue;
+
+    const ask = data.ask;
+    const validAsk =
+      ask &&
+      typeof ask === "object" &&
+      typeof ask.scopeKey === "string" &&
+      typeof ask.anchorLineId === "string" &&
+      typeof ask.text === "string"
+        ? ask
+        : undefined;
+
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        cacheKey: data.cacheKey,
+        ask: validAsk,
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return latest?.ask;
+}
+
+export function persistCachedAsk(
+  pi: ExtensionAPI,
+  cacheKey: string,
+  ask?: PersistedAsk,
+): void {
+  pi.appendEntry(REVIEW_ASK_CACHE_ENTRY, {
+    cacheKey,
+    ask,
+    updatedAt: Date.now(),
+  } satisfies ReviewAskCacheEntry);
+}

--- a/src/review/component.ts
+++ b/src/review/component.ts
@@ -41,6 +41,7 @@ import type {
   SelectionBounds,
   SplitDiffCell,
   SplitDiffRow,
+  WorkspaceCommentSummary,
 } from "./types.ts";
 
 type InlineBoxPart = "top" | "body" | "bottom";
@@ -122,6 +123,9 @@ export class ReviewComponent {
     private onExplanationsChanged?: (explanations: Map<string, string>) => void,
     cachedAsk?: PersistedAsk,
     private onAskChanged?: (ask?: PersistedAsk) => void,
+    private getWorkspaceCommentSummary?: (
+      comments: Map<string, ReviewComment>,
+    ) => WorkspaceCommentSummary | undefined,
   ) {
     const firstCommentable = this.lines.findIndex((line) => line.commentable);
     this.navigation = new ReviewNavigationState(
@@ -394,11 +398,12 @@ export class ReviewComponent {
   render(width: number): string[] {
     const viewportHeight = this.getContentHeight();
     const selectedLine = this.lines[this.selected];
+    const workspaceSummary = this.getWorkspaceCommentSummary?.(this.comments);
     const output: string[] = [];
 
     output.push(
       this.renderStatusLine(
-        this.getHeaderText(selectedLine),
+        this.getHeaderText(selectedLine, workspaceSummary),
         "Press h for help",
         width,
       ),
@@ -409,15 +414,21 @@ export class ReviewComponent {
 
     output.push(
       truncateToWidth(
-        this.theme.fg("muted", this.getFooterText(selectedLine)),
+        this.theme.fg(
+          "muted",
+          this.getFooterText(selectedLine, workspaceSummary),
+        ),
         width,
       ),
     );
     return this.helpVisible ? this.renderHelpModal(output, width) : output;
   }
 
-  private getHeaderText(selectedLine?: ReviewLine): string {
-    const base = `${this.title} • ${this.lines.length} lines • ${this.comments.size} comments`;
+  private getHeaderText(
+    selectedLine?: ReviewLine,
+    workspaceSummary?: WorkspaceCommentSummary,
+  ): string {
+    const base = `${this.title} • ${this.lines.length} lines • ${this.comments.size} comments${this.formatWorkspaceSummary(workspaceSummary)}`;
 
     if (this.editMode) {
       return `${base} • editing ${this.editingCommentKey === GLOBAL_COMMENT_KEY ? "overall comment" : "inline comment"}`;
@@ -1209,7 +1220,10 @@ export class ReviewComponent {
       : position;
   }
 
-  private getFooterText(selectedLine?: ReviewLine): string {
+  private getFooterText(
+    selectedLine?: ReviewLine,
+    workspaceSummary?: WorkspaceCommentSummary,
+  ): string {
     if (this.search.mode) {
       return `Search: /${this.search.draftQuery} • Enter jump • Esc cancel`;
     }
@@ -1224,7 +1238,27 @@ export class ReviewComponent {
       const endLine = this.lines[selection.end]!;
       return `Selected ${count} lines: ${formatLocation(startLine)} -> ${formatLocation(endLine)}`;
     }
-    return `Selected: ${selectedLine ? formatLocation(selectedLine) : "(no selection)"}`;
+
+    const selectedText = `Selected: ${selectedLine ? formatLocation(selectedLine) : "(no selection)"}`;
+    const workspaceText = this.formatWorkspaceSummary(workspaceSummary, false);
+    return workspaceText ? `${selectedText} • ${workspaceText}` : selectedText;
+  }
+
+  private formatWorkspaceSummary(
+    summary?: WorkspaceCommentSummary,
+    includeVisible = true,
+  ): string {
+    if (!summary) return "";
+
+    const parts: string[] = [];
+    if (includeVisible && summary.visible > 0) parts.push(`${summary.visible} visible persisted`);
+    if (summary.hiddenInCurrentFiles > 0) {
+      parts.push(`${summary.hiddenInCurrentFiles} hidden in current files`);
+    }
+    if (summary.elsewhere > 0) parts.push(`${summary.elsewhere} elsewhere`);
+    if (summary.stale > 0) parts.push(`${summary.stale} stale`);
+    if (summary.orphaned > 0) parts.push(`${summary.orphaned} orphaned`);
+    return parts.length > 0 ? ` • ${parts.join(" • ")}` : "";
   }
 
   private jumpHunk(direction: 1 | -1): void {

--- a/src/review/prompt.ts
+++ b/src/review/prompt.ts
@@ -37,15 +37,38 @@ export function buildReviewPrompt(
   comments: ReviewComment[],
   promptLabel: string,
 ): string {
+  return buildCommentPrompt(
+    comments,
+    `Address this local code review feedback for ${promptLabel}.`,
+    "diff",
+  );
+}
+
+export function buildViewReviewPrompt(
+  comments: ReviewComment[],
+  promptLabel: string,
+): string {
+  return buildCommentPrompt(
+    comments,
+    `Address this code review feedback for ${promptLabel}.`,
+    "ts",
+  );
+}
+
+function buildCommentPrompt(
+  comments: ReviewComment[],
+  intro: string,
+  codeFenceLanguage: string,
+): string {
   const body = comments
     .map((comment) => {
       const location = formatCommentLocation(comment);
       const excerpt = comment.lineText.trim()
-        ? `\n  Excerpt:\n\n\`\`\`diff\n${comment.lineText}\n\`\`\``
+        ? `\n  Excerpt:\n\n\`\`\`${codeFenceLanguage}\n${comment.lineText}\n\`\`\``
         : "";
       return `- \`${location}\` — ${comment.text}${excerpt}`;
     })
     .join("\n");
 
-  return `Address this local code review feedback for ${promptLabel}.\n\n## Review comments\n${body}\n\nPlease apply the feedback and summarize what changed.`;
+  return `${intro}\n\n## Review comments\n${body}\n\nPlease apply the feedback and summarize what changed.`;
 }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -48,6 +48,14 @@ export type PersistedAsk = {
   text: string;
 };
 
+export type WorkspaceCommentSummary = {
+  visible: number;
+  hiddenInCurrentFiles: number;
+  elsewhere: number;
+  stale: number;
+  orphaned: number;
+};
+
 export type DiffRenderMode = "unified" | "split";
 
 export type SplitDiffCell = {

--- a/src/review/workspace-comments.ts
+++ b/src/review/workspace-comments.ts
@@ -1,0 +1,448 @@
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import type { ReviewComment, ReviewLine } from "./types.ts";
+
+const STORE_VERSION = 1;
+const MAX_CONTEXT_LINES = 2;
+
+export type PersistentCommentStatus = "active" | "stale" | "orphaned";
+
+export type WorkspaceCommentRecord = {
+  id: string;
+  filePath: string;
+  text: string;
+  startLine: number;
+  endLine: number;
+  excerpt: string;
+  beforeContext: string[];
+  afterContext: string[];
+  fileContentHash: string;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type ResolvedWorkspaceComment = WorkspaceCommentRecord & {
+  status: PersistentCommentStatus;
+  resolvedStartLine?: number;
+  resolvedEndLine?: number;
+};
+
+type WorkspaceCommentStoreFile = {
+  version: number;
+  comments: WorkspaceCommentRecord[];
+};
+
+export type WorkspaceCommentSummary = {
+  visible: number;
+  hiddenInCurrentFiles: number;
+  elsewhere: number;
+  stale: number;
+  orphaned: number;
+};
+
+export class WorkspaceCommentStore {
+  private readonly storePath: string;
+  private readonly root: string;
+
+  constructor(cwd: string) {
+    this.root = getWorkspaceRoot(cwd);
+    this.storePath = getStorePath(cwd, this.root);
+  }
+
+  get rootPath(): string {
+    return this.root;
+  }
+
+  list(): WorkspaceCommentRecord[] {
+    return readStoreFile(this.storePath).comments;
+  }
+
+  resolveAll(): ResolvedWorkspaceComment[] {
+    return this.list().map((comment) => this.resolveComment(comment));
+  }
+
+  getVisibleComments(lines: ReviewLine[]): Map<string, ReviewComment> {
+    const visible = new Map<string, ReviewComment>();
+    const lineByFileAndNumber = buildLineLookup(lines);
+
+    for (const comment of this.resolveAll()) {
+      if (comment.status === "orphaned") continue;
+      const startLine = comment.resolvedStartLine ?? comment.startLine;
+      const endLine = comment.resolvedEndLine ?? comment.endLine;
+      const start = lineByFileAndNumber.get(getFileLineKey(comment.filePath, startLine));
+      const end = lineByFileAndNumber.get(getFileLineKey(comment.filePath, endLine));
+      if (!start || !end) continue;
+      const reviewCommentId = `${start.id}:${end.id}`;
+      visible.set(reviewCommentId, {
+        id: reviewCommentId,
+        filePath: comment.filePath,
+        text: comment.text,
+        startLineId: start.id,
+        endLineId: end.id,
+        startNewLineNumber: startLine,
+        endNewLineNumber: endLine,
+        lineText: comment.excerpt,
+      });
+    }
+
+    return visible;
+  }
+
+  summarize(lines: ReviewLine[]): WorkspaceCommentSummary {
+    const lineByFileAndNumber = buildLineLookup(lines);
+    const currentFiles = new Set(lines.map((line) => line.filePath).filter(isPresent));
+    const visible = new Set<string>();
+    let hiddenInCurrentFiles = 0;
+    let elsewhere = 0;
+    let stale = 0;
+    let orphaned = 0;
+
+    for (const comment of this.resolveAll()) {
+      if (comment.status === "stale") stale++;
+      if (comment.status === "orphaned") {
+        orphaned++;
+        continue;
+      }
+
+      const startLine = comment.resolvedStartLine ?? comment.startLine;
+      const endLine = comment.resolvedEndLine ?? comment.endLine;
+      const startVisible = lineByFileAndNumber.has(
+        getFileLineKey(comment.filePath, startLine),
+      );
+      const endVisible = lineByFileAndNumber.has(
+        getFileLineKey(comment.filePath, endLine),
+      );
+
+      if (startVisible && endVisible) {
+        visible.add(comment.id);
+        continue;
+      }
+
+      if (currentFiles.has(comment.filePath)) {
+        hiddenInCurrentFiles++;
+      } else {
+        elsewhere++;
+      }
+    }
+
+    return {
+      visible: visible.size,
+      hiddenInCurrentFiles,
+      elsewhere,
+      stale,
+      orphaned,
+    };
+  }
+
+  syncFromComments(lines: ReviewLine[], comments: Iterable<ReviewComment>): void {
+    const store = readStoreFile(this.storePath);
+    const next = new Map(store.comments.map((comment) => [comment.id, comment]));
+    const commentIdsForCurrentFiles = new Set<string>();
+    const currentFiles = new Set(lines.map((line) => line.filePath).filter(isPresent));
+
+    for (const comment of store.comments) {
+      if (currentFiles.has(comment.filePath)) {
+        commentIdsForCurrentFiles.add(comment.id);
+      }
+    }
+
+    for (const id of commentIdsForCurrentFiles) {
+      next.delete(id);
+    }
+
+    for (const comment of comments) {
+      const previous = this.getPreviousRecord(lines, comment, next);
+      const record = this.buildRecord(lines, comment, previous);
+      if (record) next.set(record.id, record);
+    }
+
+    writeStoreFile(this.storePath, { version: STORE_VERSION, comments: [...next.values()] });
+  }
+
+  private getPreviousRecord(
+    lines: ReviewLine[],
+    comment: ReviewComment,
+    commentsById: Map<string, WorkspaceCommentRecord>,
+  ): WorkspaceCommentRecord | undefined {
+    if (comment.global) return undefined;
+    const start = lines.find((line) => line.id === comment.startLineId);
+    const end = lines.find((line) => line.id === comment.endLineId);
+    const filePath = normalizePath(comment.filePath);
+    const startLine = start?.newLineNumber;
+    const endLine = end?.newLineNumber;
+    if (!filePath || startLine == null || endLine == null) return undefined;
+    return commentsById.get(
+      getPersistentCommentId(
+        filePath,
+        Math.max(1, Math.min(startLine, endLine)),
+        Math.max(startLine, endLine),
+      ),
+    );
+  }
+
+  private buildRecord(
+    lines: ReviewLine[],
+    comment: ReviewComment,
+    previous?: WorkspaceCommentRecord,
+  ): WorkspaceCommentRecord | undefined {
+    if (comment.global) return undefined;
+    const start = lines.find((line) => line.id === comment.startLineId);
+    const end = lines.find((line) => line.id === comment.endLineId);
+    const filePath = normalizePath(comment.filePath);
+    if (!start || !end || !filePath) return undefined;
+    const startLine = start.newLineNumber;
+    const endLine = end.newLineNumber;
+    if (startLine == null || endLine == null) return undefined;
+
+    const absolutePath = resolve(this.root, filePath);
+    const currentLines = readTextLines(absolutePath);
+    if (!currentLines) return undefined;
+
+    const from = Math.max(1, Math.min(startLine, endLine));
+    const to = Math.max(startLine, endLine);
+    const excerpt = currentLines.slice(from - 1, to).join("\n");
+    const beforeContext = currentLines.slice(Math.max(0, from - 1 - MAX_CONTEXT_LINES), from - 1);
+    const afterContext = currentLines.slice(to, Math.min(currentLines.length, to + MAX_CONTEXT_LINES));
+    const now = Date.now();
+
+    return {
+      id: getPersistentCommentId(filePath, from, to),
+      filePath,
+      text: comment.text,
+      startLine,
+      endLine,
+      excerpt,
+      beforeContext,
+      afterContext,
+      fileContentHash: hashText(currentLines.join("\n")),
+      createdAt: previous?.createdAt ?? now,
+      updatedAt: now,
+    };
+  }
+
+  private resolveComment(comment: WorkspaceCommentRecord): ResolvedWorkspaceComment {
+    const absolutePath = resolve(this.root, comment.filePath);
+    const currentLines = readTextLines(absolutePath);
+    if (!currentLines) {
+      return { ...comment, status: "orphaned" };
+    }
+
+    const currentHash = hashText(currentLines.join("\n"));
+    const expectedExcerpt = currentLines
+      .slice(comment.startLine - 1, comment.endLine)
+      .join("\n");
+
+    if (currentHash === comment.fileContentHash && expectedExcerpt === comment.excerpt) {
+      return {
+        ...comment,
+        status: "active",
+        resolvedStartLine: comment.startLine,
+        resolvedEndLine: comment.endLine,
+      };
+    }
+
+    const exactMatch = findExcerptMatch(currentLines, comment.excerpt);
+    if (exactMatch) {
+      return {
+        ...comment,
+        status: "stale",
+        resolvedStartLine: exactMatch.startLine,
+        resolvedEndLine: exactMatch.endLine,
+      };
+    }
+
+    const contextualMatch = findContextualMatch(currentLines, comment);
+    if (contextualMatch) {
+      return {
+        ...comment,
+        status: "stale",
+        resolvedStartLine: contextualMatch.startLine,
+        resolvedEndLine: contextualMatch.endLine,
+      };
+    }
+
+    return { ...comment, status: "orphaned" };
+  }
+}
+
+function buildLineLookup(lines: ReviewLine[]): Map<string, ReviewLine> {
+  const lookup = new Map<string, ReviewLine>();
+  for (const line of lines) {
+    const filePath = normalizePath(line.filePath);
+    const lineNumber = line.newLineNumber ?? line.oldLineNumber;
+    if (!filePath || lineNumber == null) continue;
+    lookup.set(getFileLineKey(filePath, lineNumber), line);
+  }
+  return lookup;
+}
+
+function findExcerptMatch(
+  lines: string[],
+  excerpt: string,
+): { startLine: number; endLine: number } | undefined {
+  const excerptLines = excerpt.split("\n");
+  if (excerptLines.length === 0 || !excerpt.trim()) return undefined;
+
+  let match: { startLine: number; endLine: number } | undefined;
+  for (let index = 0; index <= lines.length - excerptLines.length; index++) {
+    const candidate = lines.slice(index, index + excerptLines.length).join("\n");
+    if (candidate !== excerpt) continue;
+    if (match) return undefined;
+    match = { startLine: index + 1, endLine: index + excerptLines.length };
+  }
+  return match;
+}
+
+function findContextualMatch(
+  lines: string[],
+  comment: WorkspaceCommentRecord,
+): { startLine: number; endLine: number } | undefined {
+  const excerptLines = comment.excerpt.split("\n");
+  const before = comment.beforeContext;
+  const after = comment.afterContext;
+  if (excerptLines.length === 0) return undefined;
+
+  let best:
+    | { startLine: number; endLine: number; score: number }
+    | undefined;
+
+  for (let index = 0; index <= lines.length - excerptLines.length; index++) {
+    const candidateLines = lines.slice(index, index + excerptLines.length);
+    let score = 0;
+    if (candidateLines.join("\n") === comment.excerpt) score += 10;
+
+    const beforeCandidate = lines.slice(Math.max(0, index - before.length), index);
+    const afterCandidate = lines.slice(index + excerptLines.length, index + excerptLines.length + after.length);
+    score += countSuffixMatches(beforeCandidate, before);
+    score += countPrefixMatches(afterCandidate, after);
+    score -= Math.abs(index + 1 - comment.startLine) * 0.01;
+
+    if (!best || score > best.score) {
+      best = { startLine: index + 1, endLine: index + excerptLines.length, score };
+    } else if (best && score === best.score) {
+      best = undefined;
+    }
+  }
+
+  return best && best.score > 0 ? best : undefined;
+}
+
+function countSuffixMatches(left: string[], right: string[]): number {
+  let count = 0;
+  for (let i = 1; i <= Math.min(left.length, right.length); i++) {
+    if (left[left.length - i] !== right[right.length - i]) break;
+    count++;
+  }
+  return count;
+}
+
+function countPrefixMatches(left: string[], right: string[]): number {
+  let count = 0;
+  for (let i = 0; i < Math.min(left.length, right.length); i++) {
+    if (left[i] !== right[i]) break;
+    count++;
+  }
+  return count;
+}
+
+function readTextLines(path: string): string[] | undefined {
+  try {
+    const text = readFileSync(path, "utf8");
+    return text.replace(/\r\n/g, "\n").split("\n");
+  } catch {
+    return undefined;
+  }
+}
+
+function hashText(text: string): string {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function readStoreFile(path: string): WorkspaceCommentStoreFile {
+  try {
+    if (!existsSync(path)) return { version: STORE_VERSION, comments: [] };
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as Partial<WorkspaceCommentStoreFile>;
+    const comments = Array.isArray(parsed.comments)
+      ? parsed.comments.filter(isWorkspaceCommentRecord)
+      : [];
+    return { version: STORE_VERSION, comments };
+  } catch {
+    return { version: STORE_VERSION, comments: [] };
+  }
+}
+
+function writeStoreFile(path: string, store: WorkspaceCommentStoreFile): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(store, null, 2)}\n`, "utf8");
+}
+
+function isWorkspaceCommentRecord(value: unknown): value is WorkspaceCommentRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<WorkspaceCommentRecord>;
+  return (
+    typeof record.id === "string" &&
+    typeof record.filePath === "string" &&
+    typeof record.text === "string" &&
+    typeof record.startLine === "number" &&
+    typeof record.endLine === "number" &&
+    typeof record.excerpt === "string" &&
+    Array.isArray(record.beforeContext) &&
+    Array.isArray(record.afterContext) &&
+    typeof record.fileContentHash === "string" &&
+    typeof record.createdAt === "number" &&
+    typeof record.updatedAt === "number"
+  );
+}
+
+function getWorkspaceRoot(cwd: string): string {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (result.status === 0) {
+    const root = result.stdout.trim();
+    if (root) return root;
+  }
+  return cwd;
+}
+
+function getStorePath(cwd: string, root: string): string {
+  const gitPathResult = spawnSync("git", ["rev-parse", "--git-path", "pi-diff-review-comments.json"], {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (gitPathResult.status === 0) {
+    const gitPath = gitPathResult.stdout.trim();
+    if (gitPath) return isAbsolute(gitPath) ? gitPath : resolve(root, gitPath);
+  }
+  return resolve(root, ".pi-diff-review-comments.json");
+}
+
+function normalizePath(path?: string): string | undefined {
+  if (!path) return undefined;
+  return path.replace(/\\/g, "/");
+}
+
+function getFileLineKey(filePath: string, lineNumber: number): string {
+  return `${filePath}:${lineNumber}`;
+}
+
+function getPersistentCommentId(
+  filePath: string,
+  startLine: number,
+  endLine: number,
+): string {
+  return `${filePath}:${startLine}-${endLine}`;
+}
+
+function isPresent<T>(value: T | undefined): value is T {
+  return value != null;
+}
+
+export function getRelativeWorkspacePath(root: string, path: string): string {
+  return normalizePath(relative(root, path)) ?? path;
+}

--- a/src/shared/args.ts
+++ b/src/shared/args.ts
@@ -1,0 +1,44 @@
+export function tokenizeShellArgs(input: string): string[] {
+  const args: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | undefined;
+  let escaping = false;
+
+  for (const char of input) {
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === "\\" && quote !== "'") {
+      escaping = true;
+      continue;
+    }
+
+    if ((char === '"' || char === "'") && !quote) {
+      quote = char;
+      continue;
+    }
+
+    if (char === quote) {
+      quote = undefined;
+      continue;
+    }
+
+    if (/\s/.test(char) && !quote) {
+      if (current) {
+        args.push(current);
+        current = "";
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping) current += "\\";
+  if (quote) throw new Error(`Unterminated ${quote} quote in arguments`);
+  if (current) args.push(current);
+  return args;
+}

--- a/src/view/parser.ts
+++ b/src/view/parser.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import type { ReviewLine } from "../review/types.ts";
+import { getRelativeWorkspacePath } from "../review/workspace-comments.ts";
+
+export function parseViewFiles(
+  workspaceRoot: string,
+  absolutePaths: string[],
+): ReviewLine[] {
+  const lines: ReviewLine[] = [];
+  let lineIndex = 0;
+
+  for (const absolutePath of absolutePaths) {
+    const filePath = getRelativeWorkspacePath(workspaceRoot, absolutePath);
+    lines.push({
+      id: `line-${lineIndex++}`,
+      kind: "meta",
+      text: `# ${filePath}`,
+      filePath,
+      commentable: false,
+    });
+
+    const content = readFileSync(absolutePath, "utf8").replace(/\r\n/g, "\n");
+    const fileLines = content.split("\n");
+    const hasTrailingNewline = content.endsWith("\n");
+    const visibleLines = hasTrailingNewline
+      ? fileLines.slice(0, -1)
+      : fileLines;
+
+    if (visibleLines.length === 0) {
+      lines.push({
+        id: `line-${lineIndex++}`,
+        kind: "context",
+        text: " ",
+        filePath,
+        newLineNumber: 1,
+        commentable: true,
+      });
+      continue;
+    }
+
+    visibleLines.forEach((text, index) => {
+      lines.push({
+        id: `line-${lineIndex++}`,
+        kind: "context",
+        text: ` ${text}`,
+        filePath,
+        newLineNumber: index + 1,
+        commentable: true,
+      });
+    });
+  }
+
+  return lines;
+}

--- a/src/view/source.ts
+++ b/src/view/source.ts
@@ -1,0 +1,128 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { extname, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { tokenizeShellArgs } from "../shared/args.ts";
+
+const DEFAULT_MAX_FILE_BYTES = 256 * 1024;
+const IGNORED_DIRS = new Set([".git", "node_modules"]);
+
+export type ViewSource = {
+  label: string;
+  promptLabel: string;
+  paths: string[];
+};
+
+export function parseViewSource(args: string): ViewSource {
+  const trimmed = args.trim();
+  if (!trimmed) {
+    throw new Error("Provide one or more files or folders to /view.");
+  }
+
+  let paths: string[];
+  try {
+    paths = tokenizeShellArgs(trimmed);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(message.replace(/in arguments$/, "in /view paths"));
+  }
+
+  const normalizedPaths = paths.map(stripPiPathPrefix);
+
+  return {
+    label: `/view ${trimmed}`,
+    promptLabel: `the selected code from /view ${trimmed}`,
+    paths: normalizedPaths,
+  };
+}
+
+export function resolveViewFiles(cwd: string, source: ViewSource): string[] {
+  const gitFilesByDir = new Map<string, string[]>();
+  const resolved = new Set<string>();
+
+  for (const inputPath of source.paths) {
+    const absolutePath = resolve(cwd, inputPath);
+    const stats = statSync(absolutePath, { throwIfNoEntry: false });
+    if (!stats) throw new Error(`Path does not exist: ${inputPath}`);
+
+    if (stats.isDirectory()) {
+      const gitFiles = getGitTrackedAndUntrackedFiles(cwd, inputPath, gitFilesByDir);
+      if (gitFiles) {
+        for (const file of gitFiles) resolved.add(resolve(cwd, file));
+        continue;
+      }
+
+      for (const file of walkDirectory(absolutePath)) {
+        resolved.add(file);
+      }
+      continue;
+    }
+
+    if (stats.isFile()) {
+      resolved.add(absolutePath);
+    }
+  }
+
+  const files = [...resolved].filter((path) => isViewableTextFile(path));
+  files.sort((left, right) => left.localeCompare(right));
+  return files;
+}
+
+function getGitTrackedAndUntrackedFiles(
+  cwd: string,
+  dir: string,
+  cache: Map<string, string[]>,
+): string[] | undefined {
+  const cached = cache.get(dir);
+  if (cached) return cached;
+
+  const result = spawnSync(
+    "git",
+    ["ls-files", "--cached", "--others", "--exclude-standard", "--", dir],
+    {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    },
+  );
+  if (result.status !== 0) return undefined;
+
+  const files = result.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+  cache.set(dir, files);
+  return files;
+}
+
+function* walkDirectory(dir: string): Generator<string> {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const entryPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkDirectory(entryPath);
+    } else if (entry.isFile()) {
+      yield entryPath;
+    }
+  }
+}
+
+function stripPiPathPrefix(path: string): string {
+  return path.startsWith("@") ? path.slice(1) : path;
+}
+
+function isViewableTextFile(path: string): boolean {
+  const stats = statSync(path, { throwIfNoEntry: false });
+  if (!stats?.isFile()) return false;
+  if (stats.size > DEFAULT_MAX_FILE_BYTES) return false;
+  if (extname(path).toLowerCase() === ".png") return false;
+
+  try {
+    const sample = readFileSync(path);
+    if (sample.includes(0)) return false;
+  } catch {
+    return false;
+  }
+
+  return true;
+}

--- a/test/review/component.test.ts
+++ b/test/review/component.test.ts
@@ -55,6 +55,7 @@ function createComponent(
     undefined,
     options.cachedAsk,
     options.onAskChanged,
+    undefined,
   );
 }
 

--- a/test/review/workspace-comments.test.ts
+++ b/test/review/workspace-comments.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import type { ReviewComment, ReviewLine } from "../../src/review/types.ts";
+import { WorkspaceCommentStore } from "../../src/review/workspace-comments.ts";
+
+function buildLines(filePath: string, texts: string[]): ReviewLine[] {
+  return texts.map((text, index) => ({
+    id: `line-${index}`,
+    kind: "context" as const,
+    text: ` ${text}`,
+    filePath,
+    newLineNumber: index + 1,
+    commentable: true,
+  }));
+}
+
+function buildComment(lines: ReviewLine[], lineNumber: number, text: string): ReviewComment {
+  const line = lines[lineNumber - 1]!;
+  return {
+    id: `${line.id}:${line.id}`,
+    filePath: line.filePath!,
+    text,
+    startLineId: line.id,
+    endLineId: line.id,
+    startNewLineNumber: lineNumber,
+    endNewLineNumber: lineNumber,
+    lineText: line.text,
+  };
+}
+
+describe("WorkspaceCommentStore", () => {
+  it("persists file comments and marks them stale after the file changes", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-diff-review-store-"));
+    try {
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      mkdirSync(join(cwd, "src"), { recursive: true });
+      const filePath = join(cwd, "src", "example.ts");
+      writeFileSync(filePath, "one\ntwo\nthree\n", "utf8");
+
+      const store = new WorkspaceCommentStore(cwd);
+      const lines = buildLines("src/example.ts", ["one", "two", "three"]);
+      store.syncFromComments(lines, [buildComment(lines, 2, "check this")]);
+
+      let summary = store.summarize(lines);
+      assert.equal(summary.visible, 1);
+      assert.equal(summary.stale, 0);
+
+      writeFileSync(filePath, "zero\none\ntwo\nthree\n", "utf8");
+      const movedLines = buildLines("src/example.ts", ["zero", "one", "two", "three"]);
+      summary = store.summarize(movedLines);
+      assert.equal(summary.visible, 1);
+      assert.equal(summary.stale, 1);
+
+      const visible = [...store.getVisibleComments(movedLines).values()];
+      assert.equal(visible[0]?.startNewLineNumber, 3);
+      assert.equal(visible[0]?.text, "check this");
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/view/source.test.ts
+++ b/test/view/source.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { parseViewSource, resolveViewFiles } from "../../src/view/source.ts";
+
+describe("parseViewSource", () => {
+  it("requires at least one path", () => {
+    assert.throws(() => parseViewSource(""), /Provide one or more files or folders/);
+  });
+
+  it("tokenizes quoted paths", () => {
+    assert.deepEqual(parseViewSource("src 'file name.ts'").paths, [
+      "src",
+      "file name.ts",
+    ]);
+  });
+
+  it("strips pi @ path prefixes", () => {
+    assert.deepEqual(parseViewSource("@src @'file name.ts'").paths, [
+      "src",
+      "file name.ts",
+    ]);
+  });
+});
+
+describe("resolveViewFiles", () => {
+  it("expands folders and skips binary files", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-diff-review-view-"));
+    try {
+      execFileSync("git", ["init"], { cwd, stdio: "ignore" });
+      mkdirSync(join(cwd, "src"), { recursive: true });
+      writeFileSync(join(cwd, "src", "a.ts"), "export const a = 1;\n");
+      writeFileSync(join(cwd, "src", "image.png"), Buffer.from([0, 1, 2]));
+      writeFileSync(join(cwd, "notes.md"), "hello\n");
+
+      const files = resolveViewFiles(cwd, parseViewSource("src notes.md"));
+
+      assert.deepEqual(files.map((file) => file.replace(`${cwd}/`, "")), [
+        "notes.md",
+        "src/a.ts",
+      ]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `/view` command for reviewing files and folders in the existing TUI
- persist workspace file comments with re-anchoring and stale/orphaned detection
- surface hidden, elsewhere, stale, and orphaned persisted comment counts in `/diff` and `/view`
- strip leading `@` from `/view` paths so pi file autocomplete works naturally

## Testing
- npm run check

Closes #31