### PR TITLE
Support pi @ pathspecs in /diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ Review a branch or commit range by passing any `git diff` arguments after `/diff
 /diff main...HEAD
 ```
 
+Review a single file by using a git pathspec after `--`. Pi path autocomplete works here too:
+
+```text
+/diff -- @src/index.ts
+/diff --cached -- @src/index.ts
+/diff main...HEAD -- @src/index.ts
+```
+
 `/diff <git-diff-args>` is passed through to `git diff`, so these examples are equivalent to running `git diff`, `git diff --cached`, and `git diff main...HEAD` locally before opening the review UI.
 
 Open one or more files or folders with `/view`:

--- a/src/diff/source.ts
+++ b/src/diff/source.ts
@@ -22,11 +22,20 @@ export function parseDiffSource(args: string): DiffSource {
 
 function tokenizeDiffArgs(input: string): string[] {
   try {
-    return tokenizeShellArgs(input);
+    return normalizeDiffPathspecs(tokenizeShellArgs(input));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(message.replace(/in arguments$/, "in git diff args"));
   }
+}
+
+function normalizeDiffPathspecs(args: string[]): string[] {
+  const separatorIndex = args.indexOf("--");
+  if (separatorIndex < 0) return args;
+
+  return args.map((arg, index) =>
+    index > separatorIndex && arg.startsWith("@") ? arg.slice(1) : arg,
+  );
 }
 
 export const DIFF_MAX_BUFFER_BYTES = 128 * 1024 * 1024;

--- a/test/diff/source.test.ts
+++ b/test/diff/source.test.ts
@@ -34,6 +34,18 @@ describe("parseDiffSource", () => {
     ]);
   });
 
+  it("strips pi @ path prefixes after --", () => {
+    assert.deepEqual(
+      parseDiffSource("main...HEAD -- @src/index.ts @'file name.ts'").args,
+      ["main...HEAD", "--", "src/index.ts", "file name.ts"],
+    );
+  });
+
+  it("preserves git revision syntax outside --", () => {
+    assert.deepEqual(parseDiffSource("@~1").args, ["@~1"]);
+    assert.deepEqual(parseDiffSource("@{upstream}").args, ["@{upstream}"]);
+  });
+
   it("throws for unterminated quotes", () => {
     assert.throws(
       () => parseDiffSource("-- 'unterminated"),


### PR DESCRIPTION
## Summary
- normalize pi `@path` prefixes in `/diff` pathspecs after `--`
- preserve git revision syntax like `@~1` and `@{upstream}` outside pathspec mode
- document single-file diff review examples in the README

## Testing
- npm run format
- npm test
- npm run typecheck