### PR TITLE
[codex] Add turn-based diff review overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ Review a single file by using a git pathspec after `--`. Pi path autocomplete wo
 
 `/diff <git-diff-args>` is passed through to `git diff`, so these examples are equivalent to running `git diff`, `git diff --cached`, and `git diff main...HEAD` locally before opening the review UI.
 
+Experimental: track reviewed turns while keeping the full overall diff visible:
+
+```text
+/diff --turn-based
+/diff --cached --turn-based
+/diff main...HEAD --turn-based -- @src/index.ts
+```
+
+Press `M` in a turn-based review to toggle the current hunk as reviewed. Later
+runs show the requested overall diff and render reviewed changed lines with a
+muted blue overlay.
+
 Open one or more files or folders with `/view`:
 
 ```text
@@ -79,6 +91,7 @@ Open one or more files or folders with `/view`:
 - `/diff --cached` reviews staged changes
 - `/diff main...HEAD` reviews changes on the current branch relative to `main`
 - `/diff <git-diff-args>` passes arguments through to `git diff`
+- `/diff --turn-based` enables experimental reviewed-turn overlays with `M`
 - `h` toggles the command help modal
 - `j/k` or arrow keys to move
 - `g/G` to jump to the top or bottom of the diff

--- a/src/diff/source.ts
+++ b/src/diff/source.ts
@@ -12,21 +12,75 @@ export function parseDiffSource(args: string): DiffSource {
     };
   }
 
-  const gitArgs = tokenizeDiffArgs(trimmed);
+  const { gitArgs, turnBased } = parseDiffArgs(trimmed);
+  if (!turnBased) {
+    return {
+      label: `git diff ${trimmed}`,
+      promptLabel: `\`git diff ${trimmed}\``,
+      args: gitArgs,
+    };
+  }
+
+  const gitDiffLabel =
+    gitArgs.length > 0 ? `git diff ${gitArgs.join(" ")}` : "unstaged git diff";
+  const promptLabel =
+    gitArgs.length > 0
+      ? `\`git diff ${gitArgs.join(" ")}\``
+      : "the current unstaged git diff";
+
   return {
-    label: `git diff ${trimmed}`,
-    promptLabel: `\`git diff ${trimmed}\``,
+    label: `${gitDiffLabel} with turn-based review overlay`,
+    promptLabel,
     args: gitArgs,
+    turnBased: true,
   };
 }
 
-function tokenizeDiffArgs(input: string): string[] {
+function parseDiffArgs(input: string): {
+  gitArgs: string[];
+  turnBased: boolean;
+} {
   try {
-    return normalizeDiffPathspecs(tokenizeShellArgs(input));
+    const tokens = tokenizeShellArgs(input);
+    const { args, turnBased } = extractDiffReviewFlags(tokens);
+    return {
+      gitArgs: normalizeDiffPathspecs(args),
+      turnBased,
+    };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(message.replace(/in arguments$/, "in git diff args"));
   }
+}
+
+function extractDiffReviewFlags(tokens: string[]): {
+  args: string[];
+  turnBased: boolean;
+} {
+  const args: string[] = [];
+  let turnBased = false;
+  let passthrough = false;
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    if (token === "--") {
+      passthrough = true;
+      args.push(token);
+      continue;
+    }
+
+    if (!passthrough && token === "--turn-based") {
+      if (turnBased) {
+        throw new Error("--turn-based can only be provided once");
+      }
+      turnBased = true;
+      continue;
+    }
+
+    args.push(token);
+  }
+
+  return { args, turnBased };
 }
 
 function normalizeDiffPathspecs(args: string[]): string[] {

--- a/src/diff/turn-based-overlay.ts
+++ b/src/diff/turn-based-overlay.ts
@@ -1,0 +1,93 @@
+import type { ReviewLine, ReviewSnapshotLine } from "../review/types.ts";
+
+export function applyReviewedOverlay(
+  targetLines: ReviewLine[],
+  reviewedLines: ReviewSnapshotLine[],
+): number {
+  const reviewedKeys = new Set(
+    reviewedLines.flatMap((line) => getChangedLineKeys(line)),
+  );
+  let marked = 0;
+
+  for (const line of targetLines) {
+    if (getChangedLineKeys(line).some((key) => reviewedKeys.has(key))) {
+      line.reviewedOverlay = true;
+      marked++;
+    }
+  }
+
+  return marked;
+}
+
+export function markChangedLinesReviewed(lines: ReviewLine[]): number {
+  let marked = 0;
+
+  for (const line of lines) {
+    if (getChangedLineKeys(line).length === 0) continue;
+    if (!line.reviewedOverlay) marked++;
+    line.reviewedOverlay = true;
+  }
+
+  return marked;
+}
+
+export function clearReviewedOverlay(lines: ReviewLine[]): number {
+  let cleared = 0;
+
+  for (const line of lines) {
+    if (!line.reviewedOverlay) continue;
+    line.reviewedOverlay = false;
+    cleared++;
+  }
+
+  return cleared;
+}
+
+export function areAllChangedLinesReviewed(lines: ReviewLine[]): boolean {
+  const changedLines = lines.filter(
+    (line) => getChangedLineKeys(line).length > 0,
+  );
+  return (
+    changedLines.length > 0 &&
+    changedLines.every((line) => line.reviewedOverlay)
+  );
+}
+
+export function getReviewedLines(lines: ReviewLine[]): ReviewLine[] {
+  return lines.filter(
+    (line) => line.reviewedOverlay && getChangedLineKeys(line).length > 0,
+  );
+}
+
+function getChangedLineKeys(line: ReviewLine | ReviewSnapshotLine): string[] {
+  if (!line.filePath) return [];
+  if (line.kind === "add" && line.newLineNumber != null) {
+    return [
+      [
+        line.filePath,
+        line.kind,
+        String(line.newLineNumber),
+        getComparableText(line),
+      ].join("\0"),
+    ];
+  }
+
+  if (line.kind === "remove" && line.oldLineNumber != null) {
+    return [
+      [
+        line.filePath,
+        line.kind,
+        String(line.oldLineNumber),
+        getComparableText(line),
+      ].join("\0"),
+    ];
+  }
+
+  return [];
+}
+
+function getComparableText(line: ReviewLine | ReviewSnapshotLine): string {
+  return line.kind === "add" || line.kind === "remove"
+    ? line.text.slice(1)
+    : line.text;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,14 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { getDiff, parseDiffSource } from "./diff/source.ts";
 import { parseDiff } from "./diff/parser.ts";
+import { applyReviewedOverlay } from "./diff/turn-based-overlay.ts";
 import { PiModelDiffExplainer } from "./explanation/explainer.ts";
 import {
+  getLastReviewSnapshot,
   getCachedAsk,
   getCachedComments,
   getCachedExplanations,
+  persistLastReviewSnapshot,
   persistCachedAsk,
   persistCachedComments,
   persistCachedExplanations,
@@ -28,6 +31,10 @@ import { parseViewSource, resolveViewFiles } from "./view/source.ts";
 function getReviewCacheKey(cwd: string, label: string, text: string): string {
   const hash = createHash("sha256").update(text).digest("hex");
   return `${cwd}\0${label}\0${hash}`;
+}
+
+function getReviewScopeKey(cwd: string, args: string[]): string {
+  return `${cwd}\0diff\0${JSON.stringify(args)}`;
 }
 
 export function registerDiffReviewCommand(pi: ExtensionAPI): void {
@@ -51,11 +58,34 @@ export function registerDiffReviewCommand(pi: ExtensionAPI): void {
       }
 
       const reviewLines = parseDiff(diffText);
+      const turnBasedScopeKey = source.turnBased
+        ? getReviewScopeKey(ctx.cwd, source.args)
+        : undefined;
+      if (turnBasedScopeKey) {
+        const previousLines = getLastReviewSnapshot(ctx, turnBasedScopeKey);
+        if (previousLines) {
+          const marked = applyReviewedOverlay(reviewLines, previousLines);
+          ctx.ui.notify(
+            `Marked ${marked} reviewed line${marked === 1 ? "" : "s"}.`,
+            "info",
+          );
+        } else {
+          ctx.ui.notify(
+            "No reviewed baseline found. Press M to toggle the current hunk as reviewed.",
+            "info",
+          );
+        }
+      }
       await openReview(pi, ctx, {
         title: source.label,
         promptLabel: source.promptLabel,
         cacheKey: getReviewCacheKey(ctx.cwd, source.label, diffText),
         reviewLines,
+        markReviewed:
+          turnBasedScopeKey == null
+            ? undefined
+            : (reviewedLines) =>
+                persistLastReviewSnapshot(pi, turnBasedScopeKey, reviewedLines),
         buildPrompt: (comments) =>
           buildReviewPrompt(comments, source.promptLabel),
       });
@@ -113,6 +143,7 @@ async function openReview(
     cacheKey: string;
     reviewLines: ReviewLine[];
     buildPrompt: (comments: ReviewComment[]) => string;
+    markReviewed?: (reviewedLines: ReviewLine[]) => void;
     workspaceStore?: WorkspaceCommentStore;
   },
 ): Promise<void> {
@@ -202,6 +233,9 @@ async function openReview(
           persistCachedAsk(pi, options.cacheKey, updatedAsk);
         },
         () => summary(),
+        options.markReviewed
+          ? (reviewedLines) => options.markReviewed?.(reviewedLines)
+          : undefined,
       );
     },
   );

--- a/src/review/cache.ts
+++ b/src/review/cache.ts
@@ -2,11 +2,17 @@ import type {
   ExtensionAPI,
   ExtensionCommandContext,
 } from "@earendil-works/pi-coding-agent";
-import type { PersistedAsk, ReviewComment } from "./types.ts";
+import type {
+  PersistedAsk,
+  ReviewComment,
+  ReviewLine,
+  ReviewSnapshotLine,
+} from "./types.ts";
 
 const REVIEW_COMMENT_CACHE_ENTRY = "pi-diff-review-cache";
 const REVIEW_EXPLANATION_CACHE_ENTRY = "pi-diff-review-explanation-cache";
 const REVIEW_ASK_CACHE_ENTRY = "pi-diff-review-ask-cache";
+const REVIEW_SNAPSHOT_CACHE_ENTRY = "pi-diff-review-snapshot-cache";
 
 type ReviewCommentCacheEntry = {
   cacheKey: string;
@@ -23,6 +29,12 @@ type ReviewExplanationCacheEntry = {
 type ReviewAskCacheEntry = {
   cacheKey: string;
   ask?: PersistedAsk;
+  updatedAt: number;
+};
+
+type ReviewSnapshotCacheEntry = {
+  scopeKey: string;
+  lines: ReviewSnapshotLine[];
   updatedAt: number;
 };
 
@@ -168,4 +180,63 @@ export function persistCachedAsk(
     ask,
     updatedAt: Date.now(),
   } satisfies ReviewAskCacheEntry);
+}
+
+export function getLastReviewSnapshot(
+  ctx: ExtensionCommandContext,
+  scopeKey: string,
+): ReviewSnapshotLine[] | undefined {
+  let latest: ReviewSnapshotCacheEntry | undefined;
+  for (const entry of ctx.sessionManager.getEntries()) {
+    if (
+      entry.type !== "custom" ||
+      entry.customType !== REVIEW_SNAPSHOT_CACHE_ENTRY
+    ) {
+      continue;
+    }
+
+    const data = entry.data as Partial<ReviewSnapshotCacheEntry> | undefined;
+    if (data?.scopeKey !== scopeKey || !Array.isArray(data.lines)) continue;
+
+    const lines = data.lines.filter(isReviewSnapshotLine);
+    if (!latest || (data.updatedAt ?? 0) >= latest.updatedAt) {
+      latest = {
+        scopeKey: data.scopeKey,
+        lines,
+        updatedAt: data.updatedAt ?? 0,
+      };
+    }
+  }
+
+  return latest?.lines;
+}
+
+export function persistLastReviewSnapshot(
+  pi: ExtensionAPI,
+  scopeKey: string,
+  lines: ReviewLine[] | ReviewSnapshotLine[],
+): void {
+  pi.appendEntry(REVIEW_SNAPSHOT_CACHE_ENTRY, {
+    scopeKey,
+    lines: lines.map((line) => ({
+      kind: line.kind,
+      text: line.text,
+      filePath: line.filePath,
+      oldLineNumber: line.oldLineNumber,
+      newLineNumber: line.newLineNumber,
+    })),
+    updatedAt: Date.now(),
+  } satisfies ReviewSnapshotCacheEntry);
+}
+
+function isReviewSnapshotLine(value: unknown): value is ReviewSnapshotLine {
+  if (!value || typeof value !== "object") return false;
+  const line = value as Partial<ReviewSnapshotLine>;
+  return (
+    typeof line.kind === "string" &&
+    typeof line.text === "string" &&
+    (line.filePath == null || typeof line.filePath === "string") &&
+    (line.oldLineNumber == null || typeof line.oldLineNumber === "number") &&
+    (line.newLineNumber == null || typeof line.newLineNumber === "number")
+  );
 }

--- a/src/review/component.ts
+++ b/src/review/component.ts
@@ -31,6 +31,12 @@ import { ReviewSearchState } from "./search.ts";
 import { buildReviewFileIndex, type ReviewFileSection } from "./files.ts";
 import { padToWidth, lineNumberCell } from "../render/utils.ts";
 import { buildSplitDiffRows } from "../diff/split.ts";
+import {
+  areAllChangedLinesReviewed,
+  clearReviewedOverlay,
+  getReviewedLines,
+  markChangedLinesReviewed,
+} from "../diff/turn-based-overlay.ts";
 import type {
   DiffRenderMode,
   PersistedAsk,
@@ -71,6 +77,7 @@ const HELP_COMMANDS = [
   ["/", "search diff lines"],
   ["n / N", "jump between search matches"],
   ["J / K", "extend highlighted selection"],
+  ["M", "toggle current hunk reviewed"],
   ["c", "add or edit a line or range comment"],
   ["C", "add or edit an overall diff comment"],
   ["x", "delete the current line or range comment"],
@@ -136,6 +143,7 @@ export class ReviewComponent {
     private getWorkspaceCommentSummary?: (
       comments: Map<string, ReviewComment>,
     ) => WorkspaceCommentSummary | undefined,
+    private onMarkReviewed?: (reviewedLines: ReviewLine[]) => void,
   ) {
     const firstCommentable = this.lines.findIndex((line) => line.commentable);
     this.navigation = new ReviewNavigationState(
@@ -400,6 +408,10 @@ export class ReviewComponent {
       this.extendSelection(-1);
       return;
     }
+    if (data === "M") {
+      this.markCurrentDiffReviewed();
+      return;
+    }
     if (data === "n") {
       if (this.search.query) {
         this.jumpSearch(1);
@@ -488,7 +500,12 @@ export class ReviewComponent {
   ): string {
     const visibleLineCount = this.getVisibleLineIndexes().length;
     const summaryCount = this.explanationController.explanations.size;
-    const base = `${visibleLineCount}/${this.lines.length} lines • ${this.fileIndex.sections.length} files • ${this.comments.size} comments • ${summaryCount} summaries${this.formatWorkspaceSummary(workspaceSummary)}`;
+    const reviewedOverlayCount = this.lines.filter(
+      (line) => line.reviewedOverlay,
+    ).length;
+    const reviewedOverlayText =
+      reviewedOverlayCount > 0 ? ` • ${reviewedOverlayCount} reviewed` : "";
+    const base = `${visibleLineCount}/${this.lines.length} lines • ${this.fileIndex.sections.length} files • ${this.comments.size} comments • ${summaryCount} summaries${reviewedOverlayText}${this.formatWorkspaceSummary(workspaceSummary)}`;
 
     if (this.editMode) {
       return `${base} • editing ${this.editingCommentKey === GLOBAL_COMMENT_KEY ? "overall comment" : "inline comment"}`;
@@ -1290,13 +1307,12 @@ export class ReviewComponent {
     index: number,
     width: number,
   ): string[] {
-    const hasComment = this.getCommentKeysForLine(index).length > 0;
-    const commentMark = hasComment ? this.theme.fg("borderAccent", "│") : " ";
+    const lineMark = this.getLineMark(line, index);
     const numbers = `${lineNumberCell(line.oldLineNumber)} ${lineNumberCell(line.newLineNumber)}`;
-    const prefix = this.styleDiffPrefix(line, `${commentMark} ${numbers} `);
+    const prefix = this.styleDiffPrefix(line, `${lineMark} ${numbers} `);
     const continuationPrefix = this.styleDiffPrefix(
       line,
-      `${commentMark} ${lineNumberCell()} ${lineNumberCell()} `,
+      `${lineMark} ${lineNumberCell()} ${lineNumberCell()} `,
     );
     return this.wrapDiffContentSegments(
       this.getRenderedDiffContent(line, index),
@@ -1312,17 +1328,16 @@ export class ReviewComponent {
     side: "left" | "right",
   ): string[] {
     const { line, index } = cell;
-    const hasComment = this.getCommentKeysForLine(index).length > 0;
-    const commentMark = hasComment ? this.theme.fg("borderAccent", "│") : " ";
+    const lineMark = this.getLineMark(line, index);
     const lineNumber =
       side === "left" ? line.oldLineNumber : line.newLineNumber;
     const prefix = this.styleDiffPrefix(
       line,
-      `${commentMark} ${lineNumberCell(lineNumber)} `,
+      `${lineMark} ${lineNumberCell(lineNumber)} `,
     );
     const continuationPrefix = this.styleDiffPrefix(
       line,
-      `${commentMark} ${lineNumberCell()} `,
+      `${lineMark} ${lineNumberCell()} `,
     );
     return this.wrapDiffContentSegments(
       this.getRenderedDiffContent(line, index),
@@ -1358,6 +1373,46 @@ export class ReviewComponent {
       default:
         return this.theme.fg("muted", text);
     }
+  }
+
+  private getLineMark(line: ReviewLine, index: number): string {
+    const hasComment = this.getCommentKeysForLine(index).length > 0;
+    if (hasComment) return this.theme.fg("borderAccent", "│");
+    return " ";
+  }
+
+  private markCurrentDiffReviewed(): void {
+    if (!this.onMarkReviewed) return;
+    const range = this.getCurrentHunkRange();
+    if (!range) return;
+
+    const hunkLines = this.lines.slice(range.start, range.end + 1);
+    if (areAllChangedLinesReviewed(hunkLines)) {
+      clearReviewedOverlay(hunkLines);
+    } else {
+      markChangedLinesReviewed(hunkLines);
+    }
+
+    this.onMarkReviewed(getReviewedLines(this.lines));
+    this.invalidateAnnotatedRows();
+    this.tui.requestRender(true);
+  }
+
+  private getCurrentHunkRange(): SelectionBounds | undefined {
+    const selectedLine = this.lines[this.selected];
+    if (!selectedLine?.filePath || !selectedLine.hunkLabel) return undefined;
+
+    let start = this.selected;
+    while (
+      start > 0 &&
+      this.lines[start - 1]?.filePath === selectedLine.filePath &&
+      this.lines[start - 1]?.hunkLabel === selectedLine.hunkLabel
+    ) {
+      start--;
+    }
+
+    const end = this.getHunkEndIndex(this.selected);
+    return end == null ? undefined : { start, end };
   }
 
   private wrapDiffContentSegments(
@@ -1793,6 +1848,9 @@ export class ReviewComponent {
     const selection = this.getSelectionBounds();
     const inSelection =
       selection != null && index >= selection.start && index <= selection.end;
+    if (line.reviewedOverlay) {
+      return this.applyReviewedBackground(styled, width);
+    }
     if (index === this.selected || inSelection) {
       return this.theme.bg("selectedBg", padToWidth(styled, width));
     }
@@ -1831,13 +1889,22 @@ export class ReviewComponent {
     styled: string,
     width: number,
   ): string {
+    if (line.reviewedOverlay) {
+      return this.applyReviewedBackground(styled, width);
+    }
+
+    const padded = padToWidth(styled, width);
     if (line.kind === "add") {
-      return this.theme.bg("toolSuccessBg", padToWidth(styled, width));
+      return this.theme.bg("toolSuccessBg", padded);
     }
     if (line.kind === "remove") {
-      return this.theme.bg("toolErrorBg", padToWidth(styled, width));
+      return this.theme.bg("toolErrorBg", padded);
     }
     return styled;
+  }
+
+  private applyReviewedBackground(styled: string, width: number): string {
+    return `\x1b[48;2;38;68;92m${padToWidth(styled, width)}\x1b[49m`;
   }
 
   private renderDiffRowContent(
@@ -1924,6 +1991,9 @@ export class ReviewComponent {
       " ".repeat(width);
     const inSelection =
       selection != null && index >= selection.start && index <= selection.end;
+    if (line.reviewedOverlay) {
+      return this.applyReviewedBackground(styled, width);
+    }
     if (selected || inSelection) {
       return this.theme.bg("selectedBg", padToWidth(styled, width));
     }

--- a/src/review/types.ts
+++ b/src/review/types.ts
@@ -25,6 +25,7 @@ export type ReviewLine = {
   newLineNumber?: number;
   commentable: boolean;
   hunkLabel?: string;
+  reviewedOverlay?: boolean;
 };
 
 export type ReviewResult =
@@ -40,7 +41,13 @@ export type DiffSource = {
   label: string;
   promptLabel: string;
   args: string[];
+  turnBased?: boolean;
 };
+
+export type ReviewSnapshotLine = Pick<
+  ReviewLine,
+  "kind" | "text" | "filePath" | "oldLineNumber" | "newLineNumber"
+>;
 
 export type PersistedAsk = {
   scopeKey: string;

--- a/test/diff/source.test.ts
+++ b/test/diff/source.test.ts
@@ -41,6 +41,15 @@ describe("parseDiffSource", () => {
     );
   });
 
+  it("extracts turn-based mode without passing it to git diff", () => {
+    assert.deepEqual(parseDiffSource("--cached --turn-based -- @src/a.ts"), {
+      label: "git diff --cached -- src/a.ts with turn-based review overlay",
+      promptLabel: "`git diff --cached -- src/a.ts`",
+      args: ["--cached", "--", "src/a.ts"],
+      turnBased: true,
+    });
+  });
+
   it("preserves git revision syntax outside --", () => {
     assert.deepEqual(parseDiffSource("@~1").args, ["@~1"]);
     assert.deepEqual(parseDiffSource("@{upstream}").args, ["@{upstream}"]);

--- a/test/diff/turn-based-overlay.test.ts
+++ b/test/diff/turn-based-overlay.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseDiff } from "../../src/diff/parser.ts";
+import {
+  applyReviewedOverlay,
+  markChangedLinesReviewed,
+} from "../../src/diff/turn-based-overlay.ts";
+
+describe("turn-based overlay", () => {
+  it("marks changed lines that are present in the reviewed baseline", () => {
+    const target = parseDiff(`diff --git a/src/example.ts b/src/example.ts
+index 1111111..2222222 100644
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -1,4 +1,4 @@
+ keep
+-before
++after
++new turn
+ done
+`);
+    const reviewed = parseDiff(`diff --git a/src/example.ts b/src/example.ts
+index 1111111..2222222 100644
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -1,3 +1,3 @@
+ keep
+-before
++after
+ done
+`);
+
+    assert.equal(applyReviewedOverlay(target, reviewed), 2);
+    assert.equal(
+      target.find((line) => line.text === "-before")?.reviewedOverlay,
+      true,
+    );
+    assert.equal(
+      target.find((line) => line.text === "+after")?.reviewedOverlay,
+      true,
+    );
+    assert.equal(
+      target.find((line) => line.text === "+new turn")?.reviewedOverlay,
+      undefined,
+    );
+  });
+
+  it("marks the current diff changed lines as reviewed", () => {
+    const lines = parseDiff(`diff --git a/src/example.ts b/src/example.ts
+index 1111111..2222222 100644
+--- a/src/example.ts
++++ b/src/example.ts
+@@ -1,3 +1,3 @@
+ keep
+-before
++after
+ done
+`);
+
+    assert.equal(markChangedLinesReviewed(lines), 2);
+    assert.equal(
+      lines.find((line) => line.text === "-before")?.reviewedOverlay,
+      true,
+    );
+    assert.equal(
+      lines.find((line) => line.text === "+after")?.reviewedOverlay,
+      true,
+    );
+    assert.equal(
+      lines.find((line) => line.text === " keep")?.reviewedOverlay,
+      undefined,
+    );
+  });
+});

--- a/test/review/component.test.ts
+++ b/test/review/component.test.ts
@@ -87,6 +87,7 @@ function createComponent(
       result: { action: "submit"; comments: any[] } | { action: "cancel" },
     ) => void;
     theme?: ReviewTheme;
+    onMarkReviewed?: (reviewedLines: ReviewLine[]) => void;
   } = {},
 ): ReviewComponent {
   const tui: ReviewTui = {
@@ -114,6 +115,7 @@ function createComponent(
     options.cachedAsk,
     options.onAskChanged,
     undefined,
+    options.onMarkReviewed,
   );
 }
 
@@ -281,6 +283,103 @@ describe("ReviewComponent", () => {
 
     assert.match(output, /<fg:warning>needle/);
     assert.match(output, /<fg:accent>needle/);
+  });
+
+  it("renders reviewed lines with a muted blue background", () => {
+    const component = createComponent(
+      [
+        {
+          id: "turn-meta",
+          kind: "meta",
+          text: "diff --git a/src/example.ts b/src/example.ts",
+          filePath: "src/example.ts",
+          commentable: false,
+        },
+        {
+          id: "turn-line",
+          kind: "add",
+          text: "+const changed = true;",
+          filePath: "src/example.ts",
+          newLineNumber: 1,
+          commentable: true,
+          reviewedOverlay: true,
+        },
+      ],
+      {
+        theme: {
+          fg: (token, text) => `<fg:${token}>${text}</fg:${token}>`,
+          bg: (token, text) => `<bg:${token}>${text}</bg:${token}>`,
+        } as ReviewTheme,
+      },
+    );
+
+    (component as any).selected = 0;
+    const output = component.render(100).join("\n");
+
+    assert.match((component as any).getHeaderText(), /1 reviewed/);
+    assert.match(output, /\x1b\[48;2;38;68;92m/);
+    assert.doesNotMatch(output, /<bg:toolSuccessBg>/);
+  });
+
+  it("toggles the current hunk as reviewed with M", () => {
+    let persisted: ReviewLine[] = [];
+    const component = createComponent(
+      [
+        {
+          id: "hunk-1",
+          kind: "hunk",
+          text: "@@ -1 +1 @@",
+          filePath: "src/example.ts",
+          commentable: false,
+          hunkLabel: "@@ -1 +1 @@",
+        },
+        {
+          id: "changed-line-1",
+          kind: "add",
+          text: "+const changed = true;",
+          filePath: "src/example.ts",
+          newLineNumber: 1,
+          commentable: true,
+          hunkLabel: "@@ -1 +1 @@",
+        },
+        {
+          id: "hunk-2",
+          kind: "hunk",
+          text: "@@ -5 +5 @@",
+          filePath: "src/example.ts",
+          commentable: false,
+          hunkLabel: "@@ -5 +5 @@",
+        },
+        {
+          id: "changed-line-2",
+          kind: "add",
+          text: "+const other = true;",
+          filePath: "src/example.ts",
+          newLineNumber: 5,
+          commentable: true,
+          hunkLabel: "@@ -5 +5 @@",
+        },
+      ],
+      {
+        onMarkReviewed: (reviewedLines) => {
+          persisted = reviewedLines;
+        },
+      },
+    );
+
+    component.handleInput("M");
+
+    assert.equal((component as any).lines[1].reviewedOverlay, true);
+    assert.equal((component as any).lines[3].reviewedOverlay, undefined);
+    assert.deepEqual(
+      persisted.map((line) => line.id),
+      ["changed-line-1"],
+    );
+
+    component.handleInput("M");
+
+    assert.equal((component as any).lines[1].reviewedOverlay, false);
+    assert.deepEqual(persisted, []);
   });
 
   it("focuses the current file and hides other files", () => {


### PR DESCRIPTION
## Summary

Adds an experimental `/diff --turn-based` mode for reviewing iterative model/agent changes while keeping the full overall diff visible.

<img width="1235" height="703" alt="image" src="https://github.com/user-attachments/assets/02c23d8f-c9a2-4168-ad09-645bd463e193" />

## Changes

- Parse and strip the `--turn-based` extension flag before invoking `git diff`.
- Persist reviewed changed lines in the session cache by diff scope.
- Add an `M` binding that toggles the current hunk as reviewed or unreviewed.
- Render reviewed changed lines with a muted blue overlay.
- Document the experimental workflow in the README.
- Add tests for parsing, overlay matching, hunk toggling, and rendering.

## Validation

- `npm run check`
- Prettier check over touched files